### PR TITLE
Have readme always point at the latest docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Shared Instrument Scripts repository.
 
 For documentation see the [wiki](https://github.com/ISISNeutronMuon/InstrumentScripts/wiki).
 
-There is also documentation for the [individual modules](https://instrumentscripts.readthedocs.io/en/scan-sans/index.html).
+There is also documentation for the [individual modules](https://instrumentscripts.readthedocs.io/en/latest/index.html).
 
 There is a temporary [continuous integration setup](https://travis-ci.org/rprospero/InstrumentScripts), but this should eventually be replaced by something with a shared ownership.
 


### PR DESCRIPTION
The docs server was pointing at my fork on github since the docs hadn't been merged onto master yet.  Now that master has docs, I've changed the link in the readme to always point at the latest version.