### PR TITLE
Add LOQ beam line

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
   # Start a fake x server so that matplotlib doesn't fail
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
-  - sudo apt-get install python-numpy python-scipy latexmk texlive-fonts-recommended
+  - sudo apt-get install python-numpy python-scipy latexmk texlive-latex-recommended texlive-latex-extra
 script:
   - ./test.sh
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
   # Start a fake x server so that matplotlib doesn't fail
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
-  - sudo apt-get install python-numpy python-scipy
+  - sudo apt-get install python-numpy python-scipy latexmk
 script:
   - ./test.sh
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
   # Start a fake x server so that matplotlib doesn't fail
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
-  - sudo apt-get install python-numpy python-scipy latexmk texlive-latex-recommended texlive-latex-extra
+  - sudo apt-get install python-numpy python-scipy latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
 script:
   - ./test.sh
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
   # Start a fake x server so that matplotlib doesn't fail
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
-  - sudo apt-get install python-numpy python-scipy latexmk
+  - sudo apt-get install python-numpy python-scipy latexmk texlive-fonts-recommended
 script:
   - ./test.sh
 cache: pip

--- a/general/scans/defaults.py
+++ b/general/scans/defaults.py
@@ -30,7 +30,6 @@ class Defaults(object):
         as keyword arguments.
 
         """
-        pass
 
     @staticmethod
     @abstractmethod
@@ -38,7 +37,6 @@ class Defaults(object):
         """
         Returns the name of a unique log file where the scan data can be saved.
         """
-        pass
 
     def scan(self, motion, start=None, stop=None, step=None, frames=None,
              **kwargs):

--- a/general/scans/fit.py
+++ b/general/scans/fit.py
@@ -275,7 +275,6 @@ class CurveFit(Fit):
         """
         This is the mathematical model to be fit by the subclass
         """
-        pass
 
     @staticmethod
     @abstractmethod
@@ -284,7 +283,6 @@ class CurveFit(Fit):
         Given a set of x and y values, make a guess as to the initial
         parameters of the fit.
         """
-        pass
 
     def fit(self, x, y):
         return curve_fit(self._model, x, y, self.guess(x, y))[0]

--- a/general/scans/monoid.py
+++ b/general/scans/monoid.py
@@ -29,14 +29,12 @@ class Monoid(object):
 
         x + x.zero() == x
         """
-        pass
 
     @abstractmethod
     def err(self):
         """
         Return the uncertainty of the current value
         """
-        pass
 
     @abstractmethod
     def __add__(self, x):

--- a/general/scans/scans.py
+++ b/general/scans/scans.py
@@ -97,23 +97,19 @@ class Scan(object):
         """The map function returns a modified scan that performs the given
         function on all of the original positions to return the new positions.
         """
-        pass
 
     @property
     @abstractmethod
     def reverse(self):
         """Create a new scan that runs in the opposite direction"""
-        pass
 
     @abstractmethod
     def min(self):
         """Find the smallest point in a scan"""
-        pass
 
     @abstractmethod
     def max(self):
         """Find the largest point in a scan"""
-        pass
 
     def __iter__(self):
         pass

--- a/instrument/loq/__init__.py
+++ b/instrument/loq/__init__.py
@@ -1,0 +1,11 @@
+"""The base module for the LOQ beamline
+
+Using a wildcard import will pull in most of the interesting
+commands for this instrument."""
+
+# pylint: disable=wildcard-import
+from instrument.loq.sans import *  # noqa: F401, F403
+from instrument.loq.scans import *  # noqa: F401, F403
+from general.scans.detector import specific_spectra  # noqa: F401
+from general.scans.fit import *  # noqa: F401, F403
+from general.scans.motion import populate  # noqa: F401

--- a/instrument/loq/sans.py
+++ b/instrument/loq/sans.py
@@ -33,7 +33,7 @@ class LOQ(ScanningInstrument):
 
     @dae_setter("SANS", "sans")
     def setup_dae_event(self):
-        raise NotImplementedError("DAE mode event unwritten for LOQ")  # FIXME
+        raise NotImplementedError("LOQ does not support event mode")
 
     @dae_setter("SANS", "sans")
     def setup_dae_histogram(self):
@@ -47,8 +47,7 @@ class LOQ(ScanningInstrument):
 
     @dae_setter("SANS", "sans")
     def setup_dae_bsalignment(self):
-        raise NotImplementedError(
-            "DAE mode bsalignment unwritten for LOQ")  # FIXME
+        raise NotImplementedError("DAE mode bsalignment unwritten for LOQ")
 
     @dae_setter("SCAN", "scan")
     def setup_dae_scanning(self):
@@ -57,12 +56,11 @@ class LOQ(ScanningInstrument):
 
     @dae_setter("SCAN", "scan")
     def setup_dae_nr(self):
-        raise NotImplementedError("DAE mode nr unwritten for LOQ")  # FIXME
+        raise NotImplementedError("LOQ cannot perform reflectometry")
 
     @dae_setter("SCAN", "scan")
     def setup_dae_nrscanning(self):
-        raise NotImplementedError(
-            "DAE mode nrscanning unwritten for LOQ")  # FIXME
+        raise NotImplementedError("LOQ cannot perform reflectometry")
 
     @staticmethod
     def set_aperature(size):

--- a/instrument/loq/sans.py
+++ b/instrument/loq/sans.py
@@ -1,0 +1,96 @@
+"""This is the instrument implementation for the LOQ beamline."""
+from technique.sans.instrument import ScanningInstrument
+from technique.sans.genie import gen
+# pylint: disable=unused-import
+from technique.sans.util import dae_setter  # noqa: F401
+from general.scans.util import local_wrapper
+
+pv_origin = "IN:LOQ"
+
+
+class LOQ(ScanningInstrument):
+    """This class handles the LOQ beamline"""
+
+    def set_measurement_type(self, value):
+        gen.set_pv(pv_origin + ":PARS:SAMPLE:MEAS:TYPE", value)
+
+    def set_measurement_label(self, value):
+        gen.set_pv(pv_origin + ":PARS:SAMPLE:MEAS:LABEL", value)
+
+    def set_measurement_id(self, value):
+        gen.set_pv(pv_origin + ":PARS:SAMPLE:MEAS:ID", value)
+
+    # FIXME
+    @staticmethod
+    def _generic_scan(  # pylint: disable=dangerous-default-value
+            detector, spectra,
+            wiring=r"card.dat",
+            tcbs=[{"low": 5.0, "high": 100000.0, "step": 200.0,
+                   "trange": 1, "log": 0}]):
+        base = r"C:\Instrument\Settings\config\NDXLOQ\configurations\tables\\"
+        ScanningInstrument._generic_scan(
+            base+detector, base+spectra, base+wiring, tcbs)
+
+    @dae_setter("SANS", "sans")
+    def setup_dae_event(self):
+        pass  # FIXME
+
+    @dae_setter("SANS", "sans")
+    def setup_dae_histogram(self):
+        pass  # FIXME
+
+    @dae_setter("TRANS", "transmission")
+    def setup_dae_transmission(self):
+        pass  # FIXME
+
+    @dae_setter("SANS", "sans")
+    def setup_dae_bsalignment(self):
+        pass  # FIXME
+
+    @dae_setter("SCAN", "scan")
+    def setup_dae_scanning(self):
+        pass  # FIXME
+
+    @dae_setter("SCAN", "scan")
+    def setup_dae_nr(self):
+        pass  # FIXME
+
+    @dae_setter("SCAN", "scan")
+    def setup_dae_nrscanning(self):
+        pass  # FIXME
+
+    @staticmethod
+    def set_aperature(size):
+        pass
+
+    @staticmethod
+    def _detector_is_on():
+        """Is the detector currently on?"""
+        pass  # FIXME
+
+    @staticmethod
+    def _detector_turn_on(delay=True):
+        raise NotImplementedError("Detector toggling is not supported LOQ")
+        # for x in range(8):
+        #     gen.set_pv(pv_origin + ":CAEN:hv0:4:{}:pwonoff".format(x), "On")
+
+    @staticmethod
+    def _detector_turn_off(delay=True):
+        raise NotImplementedError("Detector toggling is not supported on LOQ")
+        # for x in range(8):
+        #     gen.set_pv(pv_origin + ":CAEN:hv0:4:{}:pwonoff".format(x), "Off")
+
+    def _configure_sans_custom(self):
+        # move the transmission monitor out
+        gen.set_pv(pv_origin + ":VACUUM:MONITOR:4:EXTRACT", "EXTRACT")
+
+    def _configure_trans_custom(self):
+        # move the transmission monitor in
+        gen.set_pv(pv_origin + ":VACUUM:MONITOR:4:INSERT", "INSERT")
+
+
+obj = LOQ()
+for method in dir(obj):
+    if method[0] != "_" and method not in locals() and \
+       callable(getattr(obj, method)):
+        locals()[method] = local_wrapper(obj, method)

--- a/instrument/loq/sans.py
+++ b/instrument/loq/sans.py
@@ -66,7 +66,14 @@ class LOQ(ScanningInstrument):
 
     @staticmethod
     def set_aperature(size):
-        pass  # FIXME
+        if size.upper() == "SMALL":
+            gen.cset(Aperature_2="SMALL")
+        elif size.upper() == "MEDIUM":
+            gen.cset(Aperature_2="MEDIUM")
+        elif size.upper() == "LARGE":
+            gen.cset(Aperature_2="LARGE")
+        else:
+            RuntimeError("Slit size {} is undefined".format(size))
 
     @staticmethod
     def _detector_is_on():
@@ -87,10 +94,11 @@ class LOQ(ScanningInstrument):
         #     gen.set_pv(pv_origin + ":CAEN:hv0:4:{}:pwonoff".format(x), "Off")
 
     def _configure_sans_custom(self):
-        pass  # FIXME
+        gen.cset(Tx_Mon="OUT")
 
     def _configure_trans_custom(self):
-        pass  # FIXME
+        gen.cset(Aperature_2="SMALL")
+        gen.cset(Tx_Mon="IN")
 
 
 obj = LOQ()

--- a/instrument/loq/sans.py
+++ b/instrument/loq/sans.py
@@ -5,7 +5,7 @@ from technique.sans.genie import gen
 from technique.sans.util import dae_setter  # noqa: F401
 from general.scans.util import local_wrapper
 
-pv_origin = "IN:LOQ"
+pv_origin = "IN:LOQ"  # FIXME
 
 
 class LOQ(ScanningInstrument):
@@ -33,40 +33,46 @@ class LOQ(ScanningInstrument):
 
     @dae_setter("SANS", "sans")
     def setup_dae_event(self):
-        pass  # FIXME
+        raise NotImplementedError("DAE mode event unwritten for LOQ")  # FIXME
 
     @dae_setter("SANS", "sans")
     def setup_dae_histogram(self):
-        pass  # FIXME
+        raise NotImplementedError(
+            "DAE mode histogram unwritten for LOQ")  # FIXME
 
     @dae_setter("TRANS", "transmission")
     def setup_dae_transmission(self):
-        pass  # FIXME
+        raise NotImplementedError(
+            "DAE mode transmission unwritten for LOQ")  # FIXME
 
     @dae_setter("SANS", "sans")
     def setup_dae_bsalignment(self):
-        pass  # FIXME
+        raise NotImplementedError(
+            "DAE mode bsalignment unwritten for LOQ")  # FIXME
 
     @dae_setter("SCAN", "scan")
     def setup_dae_scanning(self):
-        pass  # FIXME
+        raise NotImplementedError(
+            "DAE mode scanning unwritten for LOQ")  # FIXME
 
     @dae_setter("SCAN", "scan")
     def setup_dae_nr(self):
-        pass  # FIXME
+        raise NotImplementedError("DAE mode nr unwritten for LOQ")  # FIXME
 
     @dae_setter("SCAN", "scan")
     def setup_dae_nrscanning(self):
-        pass  # FIXME
+        raise NotImplementedError(
+            "DAE mode nrscanning unwritten for LOQ")  # FIXME
 
     @staticmethod
     def set_aperature(size):
-        pass
+        pass  # FIXME
 
     @staticmethod
     def _detector_is_on():
         """Is the detector currently on?"""
-        pass  # FIXME
+        # FIXME
+        raise NotImplementedError("Detector testing is not supported on LOQ")
 
     @staticmethod
     def _detector_turn_on(delay=True):
@@ -81,12 +87,10 @@ class LOQ(ScanningInstrument):
         #     gen.set_pv(pv_origin + ":CAEN:hv0:4:{}:pwonoff".format(x), "Off")
 
     def _configure_sans_custom(self):
-        # move the transmission monitor out
-        gen.set_pv(pv_origin + ":VACUUM:MONITOR:4:EXTRACT", "EXTRACT")
+        pass  # FIXME
 
     def _configure_trans_custom(self):
-        # move the transmission monitor in
-        gen.set_pv(pv_origin + ":VACUUM:MONITOR:4:INSERT", "INSERT")
+        pass  # FIXME
 
 
 obj = LOQ()

--- a/instrument/loq/scans.py
+++ b/instrument/loq/scans.py
@@ -1,0 +1,36 @@
+"""Default class and utilities for LOQ
+
+All the scanning code specific to the LOQ instrument is
+contained in this module
+
+"""
+from __future__ import print_function
+from general.scans.defaults import Defaults
+from general.scans.detector import specific_spectra
+from general.scans.util import local_wrapper
+
+
+class LOQ(Defaults):
+    """
+    This class represents the default functions for the Zoom instrument.
+    """
+
+    detector = specific_spectra([[4]])
+
+    @staticmethod
+    def log_file():
+        from datetime import datetime
+        now = datetime.now()
+        return "U:/loq_scan_{}_{}_{}_{}_{}_{}.dat".format(
+            now.year, now.month, now.day, now.hour, now.minute, now.second)
+
+    def __repr__(self):
+        return "LOQ()"
+
+
+_loq = LOQ()
+scan = local_wrapper(_loq, "scan")
+ascan = local_wrapper(_loq, "ascan")
+dscan = local_wrapper(_loq, "dscan")
+rscan = local_wrapper(_loq, "rscan")
+print("Remember to populate")

--- a/technique/sans/instrument.py
+++ b/technique/sans/instrument.py
@@ -247,7 +247,6 @@ class ScanningInstrument(object):
           The aperature size.  e.g. "Small" or "Medium"
           A blank string (the default value) results in
           the aperature not being changed."""
-        pass
 
     def detector_lock(self, state=None):
         """Query or activate the detector lock

--- a/technique/sans/instrument.py
+++ b/technique/sans/instrument.py
@@ -134,7 +134,6 @@ class ScanningInstrument(object):
         value stored in the journal for the next run, which should be
         set to the new value.
         """
-        pass  # pragma: no cover
 
     @abstractmethod
     def set_measurement_label(self, value):  # pragma: no cover
@@ -150,7 +149,6 @@ class ScanningInstrument(object):
         value stored in the journal for the next run, which should be
         set to the new value.
         """
-        pass  # pragma: no cover
 
     @abstractmethod
     def set_measurement_id(self, value):  # pragma: no cover
@@ -166,44 +164,36 @@ class ScanningInstrument(object):
         value stored in the journal for the next run, which should be
         set to the new value.
         """
-        pass
 
     @abstractmethod
     def setup_dae_scanning(self):  # pragma: no cover
         """Set the wiring tables for a scan"""
-        pass
 
     @abstractmethod
     def setup_dae_nr(self):  # pragma: no cover
         """Set the wiring tables for a neutron
         reflectivity measurement"""
-        pass
 
     @abstractmethod
     def setup_dae_nrscanning(self):  # pragma: no cover
         """Set the wiring tables for performing
         scans during neutron reflectivity"""
-        pass
 
     @abstractmethod
     def setup_dae_event(self):  # pragma: no cover
         """Set the wiring tables for event mode"""
-        pass
 
     @abstractmethod
     def setup_dae_histogram(self):  # pragma: no cover
         """Set the wiring tables for histogram mode"""
-        pass
 
     @abstractmethod
     def setup_dae_transmission(self):  # pragma: no cover
         """Set the wiring tables for a transmission measurement"""
-        pass
 
     @abstractmethod
     def setup_dae_bsalignment(self):  # pragma: no cover
         """Configure wiring tables for beamstop alignment."""
-        pass
 
     def _configure_sans_custom(self):
         """The specific actions required by the instrument
@@ -214,7 +204,6 @@ class ScanningInstrument(object):
         overwritten by other instruments to perform any actions they
         need to put the instrument into SANS mode.
         """
-        pass
 
     def _configure_trans_custom(self):
         """The specific actions required by the instrument
@@ -225,7 +214,6 @@ class ScanningInstrument(object):
         overwritten by other instruments to perform any actions they
         need to put the instrument into SANS mode.
         """
-        pass
 
     def _begin(self, *args, **kwargs):
         """Start a measurement."""


### PR DESCRIPTION
This adds some of the skeleton code for the LOQ beam line.  We'll need to fill in the details before it can be used in production.