### PR TITLE
Ticket4913 muon begin end commands

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ flake8
 scipy
 six
 sphinx
+mock

--- a/technique/muon/muon_begin_end.py
+++ b/technique/muon/muon_begin_end.py
@@ -84,7 +84,7 @@ def set_field_sample_par(sample_pars):
     sample_pars: dict
         The sample parameters that is to contain the field parameter.
     """
-    old_field = sample_pars.get(field_par)
+    old_field = sample_pars.get(field_par, "")
     new_field = get_input("Field {}?".format(old_field))
     if new_field != "":
         g.change_sample_par(field_par, new_field)
@@ -141,10 +141,7 @@ def set_comments_sample_par(sample_pars):
     sample_pars: dict
         The sample parameters that is to contain the comments parameter.
     """
-    if comment_par in sample_pars:
-        old_comments = sample_pars[comment_par]
-    else:
-        old_comments = ""
+    old_comments = sample_pars.get(comment_par, "")
     new_comments = get_input("Comment {}?".format(old_comments))
     if new_comments != "":
         g.change_sample_par(comment_par, new_comments)

--- a/technique/muon/muon_begin_end.py
+++ b/technique/muon/muon_begin_end.py
@@ -39,10 +39,7 @@ def set_name_sample_par(sample_pars):
     sample_pars: dict
         The sample parameters that is to contain the name parameter.
     """
-    if name_par in sample_pars:
-        old_sample_name = sample_pars[name_par]
-    else:
-        old_sample_name = ""
+    old_sample_name = sample_pars.get(name_par, "")
     new_sample = get_input("Sample {}?".format(old_sample_name))
     if new_sample != "":
         g.change_sample_par(name_par, new_sample)
@@ -57,10 +54,7 @@ def set_orient_sample_par(sample_pars):
     sample_pars: dict
         The sample parameters that is to contain the orientation parameter.
     """
-    if orient_par in sample_pars:
-        old_orientation = sample_pars[orient_par]
-    else:
-        old_orientation = ""
+    old_orientation = sample_pars.get(orient_par, "")
     new_orient = get_input("Orientation {}?".format(old_orientation))
     if new_orient != "":
         g.change_sample_par(orient_par, new_orient)
@@ -75,10 +69,7 @@ def set_temp_sample_par(sample_pars):
     sample_pars: dict
         The sample parameters that is to contain the temp parameter.
     """
-    if temp_par in sample_pars:
-        old_temp = sample_pars[temp_par]
-    else:
-        old_temp = ""
+    old_temp = sample_pars.get(temp_par, "")
     new_temp = get_input("Temperature {}?".format(old_temp))
     if new_temp != "":
         g.change_sample_par(temp_par, new_temp)
@@ -93,10 +84,7 @@ def set_field_sample_par(sample_pars):
     sample_pars: dict
         The sample parameters that is to contain the field parameter.
     """
-    if field_par in sample_pars:
-        old_field = sample_pars[field_par]
-    else:
-        old_field = ""
+    old_field = sample_pars.get(field_par)
     new_field = get_input("Field {}?".format(old_field))
     if new_field != "":
         g.change_sample_par(field_par, new_field)
@@ -111,10 +99,7 @@ def set_geometry_beamline_par(beamline_pars):
     beamline_pars: dict
         The sample parameters that is to contain the geometry parameter.
     """
-    if geometry_par in beamline_pars:
-        old_geometry = beamline_pars[geometry_par]
-    else:
-        old_geometry = ""
+    old_geometry = beamline_pars.get(geometry_par, "")
     new_geometry = None
     while new_geometry not in {"", "L", "T"}:
         new_geometry = get_input("Geometry (L or T) {}?".format(old_geometry))

--- a/technique/muon/muon_begin_end.py
+++ b/technique/muon/muon_begin_end.py
@@ -207,7 +207,7 @@ def set_label(sample=True, orient=True, temp=True, field=True, geometry=True, rb
     g.change_title(new_title)
 
 
-def begin_precmd(quiet):
+def begin_precmd(**pars):
     """
     Set the run information.
 
@@ -216,8 +216,9 @@ def begin_precmd(quiet):
     quiet: bool
       If true suppress run title question output
     """
-    if not quiet:
-        set_label()
+    if 'quiet' in pars:
+        if not pars['quiet']:
+            set_label()
 
 
 def show_label():
@@ -256,7 +257,7 @@ def show_label():
     print("Run title = {}".format(g.get_title()))
 
 
-def end_precmd():
+def end_precmd(**pars):
     """
     Just before ending the run check that the run information is correct.
     """

--- a/technique/muon/run_control.py
+++ b/technique/muon/run_control.py
@@ -165,6 +165,17 @@ def set_comments_sample_par(sample_pars):
         g.change_sample_par(comment_par, new_comments)
 
 
+def construct_title():
+    """
+    Construct a run title from the run information: sample name, temperature label and field label.
+
+    Returns:
+        str: run title
+    """
+    sample_pars = g.get_sample_pars()
+    return "{}_{}_{}".format(sample_pars[name_par], sample_pars[temp_par], sample_pars[field_par])
+
+
 def set_label(sample=True, orient=True, temp=True, field=True, geometry=True, rb_num=True, exp_team=True, comment=True):
     """
     Set the run information.
@@ -206,6 +217,9 @@ def set_label(sample=True, orient=True, temp=True, field=True, geometry=True, rb
         set_users()
     if comment:
         set_comments_sample_par(sample_pars)
+    new_title = construct_title()
+    print("Run title = {}".format(new_title))
+    g.change_title(new_title)
 
 
 def begin_precmd(quiet):
@@ -254,6 +268,7 @@ def show_label():
         print("Comment = {}".format(sample_pars[comment_par]))
     else:
         print("Comment not set in sample parameters")
+    print("Run title = {}".format(g.get_title()))
 
 
 def end_precmd():

--- a/technique/muon/run_control.py
+++ b/technique/muon/run_control.py
@@ -1,0 +1,216 @@
+from __future__ import print_function
+from genie_python import genie as g
+from six.moves import input
+from time import sleep
+
+
+def get_input(prompt):
+    """
+    Get input from the user (allows us to mock it for testing)
+
+    Parameters
+    ----------
+    prompt: str
+      The stirng to prompt the user
+
+    Returns
+    -------
+    str
+      The user input
+    """
+    return input(prompt)
+
+
+name_par = "name"
+orient_par = "geometry"
+temp_par = "temp_label"
+field_par = "field_label"
+geometry_par = "geometry"
+comment_par = "comments"
+
+
+def set_name_sample_par(sample_pars):
+    if name_par in sample_pars:
+        old_sample_name = sample_pars[name_par]
+    else:
+        old_sample_name = ""
+    new_sample = get_input("Sample {}?".format(old_sample_name))
+    if new_sample != "":
+        g.change_sample_par(name_par, new_sample)
+
+
+def set_orient_sample_par(sample_pars):
+    if orient_par in sample_pars:
+        old_orientation = sample_pars[orient_par]
+    else:
+        old_orientation = ""
+    new_orient = get_input("Orientation {}?".format(old_orientation))
+    if new_orient != "":
+        g.change_sample_par(orient_par, new_orient)
+
+
+def set_temp_sample_par(sample_pars):
+    if temp_par in sample_pars:
+        old_temp = sample_pars[temp_par]
+    else:
+        old_temp = ""
+    new_temp = get_input("Temperature {}?".format(old_temp))
+    if new_temp != "":
+        g.change_sample_par(temp_par, new_temp)
+
+
+def set_field_sample_par(sample_pars):
+    if field_par in sample_pars:
+        old_field = sample_pars[field_par]
+    else:
+        old_field = ""
+    new_field = get_input("Field {}?".format(old_field))
+    if new_field != "":
+        g.change_sample_par(field_par, new_field)
+
+
+def set_geometry_beamline_par(beamline_pars):
+    if geometry_par in beamline_pars:
+        old_geometry = beamline_pars[geometry_par]
+    else:
+        old_geometry = ""
+    new_geometry = get_input("Geometry (L or T) {}?".format(old_geometry))
+    if new_geometry != "":
+        g.change_beamline_par(geometry_par, new_geometry)
+
+
+def set_rb_num():
+    old_rb_num = g.get_rb()
+    new_rb_num = get_input("RBNo {}?".format(old_rb_num))
+    if new_rb_num != "":
+        g.change_rb(new_rb_num)
+
+
+def set_users():
+    old_exp_team = g.get_users()
+    new_exp_team = get_input("Experimental Team {}?".format(old_exp_team))
+    if new_exp_team != "":
+        g.change_users(new_exp_team)
+
+
+def set_comments_sample_par(sample_pars):
+    if comment_par in sample_pars:
+        old_comments = sample_pars[comment_par]
+    else:
+        old_comments = ""
+    new_comments = get_input("Comment {}?".format(old_comments))
+    if new_comments != "":
+        g.change_sample_par(comment_par, new_comments)
+
+
+def set_label(sample=True, orient=True, temp=True, field=True, geometry=True, rb_num=True, exp_team=True, comment=True):
+    sample_pars = g.get_sample_pars()
+    if sample:
+        set_name_sample_par(sample_pars)
+    if orient:
+        set_orient_sample_par(sample_pars)
+    if temp:
+        set_temp_sample_par(sample_pars)
+    if field:
+        set_field_sample_par(sample_pars)
+    if geometry:
+        beamline_pars = g.get_beamline_pars()
+        set_geometry_beamline_par(beamline_pars)
+    if rb_num:
+        set_rb_num()
+    if exp_team:
+        set_users()
+    if comment:
+        set_comments_sample_par(sample_pars)
+
+
+def begin_precmd(quiet):
+    """
+    Set MuSR globals
+
+    Parameters
+    ----------
+    quiet: bool
+      If true suppress run title question output
+    """
+    if not quiet:
+        run_title = get_input("Run title: ")
+        g.set_title(run_title)
+        set_label()
+    sleep(1)
+
+
+def begin_postcmd(run_num, quiet):
+    """
+    Return the run number at the end of beginning the run.
+
+    Parameters
+    ----------
+    run_num: str
+      The current run number
+    quiet:
+      Suppress the output to the screen (currently there is not output,
+      but quiet is passed by begin so we have to handle it)
+
+    Returns
+    -------
+    str
+      The run number
+    """
+    return run_num
+
+
+def show_label():
+    sample_pars = g.get_sample_pars()
+    beamline_pars = g.get_beamline_pars()
+    if name_par in sample_pars:
+        print("Sample = {}".format(sample_pars[name_par]))
+    else:
+        print("Sample not set in sample parameters")
+    if orient_par in sample_pars:
+        print("Orientation = {}".format(sample_pars[orient_par]))
+    else:
+        print("Orientation not set in sample parameters")
+    if temp_par in sample_pars:
+        print("Temp = {}".format(sample_pars[temp_par]))
+    else:
+        print("Temp not set in sample parameters")
+    if field_par in sample_pars:
+        print("Field = {}".format(sample_pars[field_par]))
+    else:
+        print("Field not set in sample parameters")
+    if geometry_par in geometry_par:
+        print("Geometry = {}".format(beamline_pars[geometry_par]))
+    else:
+        print("Geometry not set in beamline parameters")
+    print("RB Number = {}".format(g.get_rb()))
+    print("Experimental Team = {}".format(g.get_users()))
+    if comment_par in sample_pars:
+        print("Comment = {}".format(sample_pars[comment_par]))
+    else:
+        print("Comment not set in sample parameters")
+
+
+def end_precmd(quiet):
+    """
+    Just before ending the run check that the run title is correct.
+
+    Parameters
+    ----------
+    quiet: bool
+      Do not ask if the run title is correct
+    """
+    if not quiet:
+        g.get_title()
+        run_title = get_input("Is \'{}\' the correct run title (y/n)?")
+        if run_title.lower() == "n":
+            g.set_title(get_input("Run title: "))
+        while True:
+            print("Run information:\n")
+            show_label()
+            label_correct = get_input("Is the run information correct (y/n)?")
+            if label_correct.lower() == "n":
+                break
+            else:
+                set_label()
+    sleep(1)

--- a/technique/muon/run_control.py
+++ b/technique/muon/run_control.py
@@ -293,5 +293,4 @@ def end_precmd(quiet):
             if label_correct.lower() == "y":
                 break
             else:
-                print("SETTING LABEL")
                 set_label()

--- a/technique/muon/run_control.py
+++ b/technique/muon/run_control.py
@@ -135,7 +135,7 @@ def begin_precmd(quiet):
     """
     if not quiet:
         run_title = get_input("Run title: ")
-        g.set_title(run_title)
+        g.change_title(run_title)
         set_label()
     sleep(1)
 
@@ -204,7 +204,7 @@ def end_precmd(quiet):
         g.get_title()
         run_title = get_input("Is \'{}\' the correct run title (y/n)?")
         if run_title.lower() == "n":
-            g.set_title(get_input("Run title: "))
+            g.change_title(get_input("Run title: "))
         while True:
             print("Run information:\n")
             show_label()

--- a/technique/muon/run_control.py
+++ b/technique/muon/run_control.py
@@ -21,13 +21,13 @@ def get_input(prompt):
 
 
 # The keys for parameters in the sample parameters dictionary
-name_par = "name"
-orient_par = "geometry"
-temp_par = "temp_label"
-field_par = "field_label"
-comment_par = "comments"
+name_par = "NAME"
+orient_par = "GEOMETRY"
+temp_par = "TEMP_LABEL"
+field_par = "FIELD_LABEL"
+comment_par = "COMMENTS"
 # The key for the geometry parameter in the beamline parameters dictionary
-geometry_par = "geometry"
+geometry_par = "GEOMETRY"
 
 
 def set_name_sample_par(sample_pars):
@@ -127,7 +127,12 @@ def set_rb_num():
     Ask the user if the rb number is correct and allow them to change it if not.
     """
     old_rb_num = g.get_rb()
-    new_rb_num = get_input("RBNo {}?".format(old_rb_num))
+    while True:
+        new_rb_num = get_input("RBNo {}?".format(old_rb_num))
+        if new_rb_num == "" or new_rb_num.isdigit():
+            break
+        else:
+            print("RB number must be a number or blank to skip setting")
     if new_rb_num != "":
         g.change_rb(new_rb_num)
 
@@ -205,7 +210,7 @@ def set_label(sample=True, orient=True, temp=True, field=True, geometry=True, rb
 
 def begin_precmd(quiet):
     """
-    Set the run title and run information.
+    Set the run information.
 
     Parameters
     ----------
@@ -213,29 +218,7 @@ def begin_precmd(quiet):
       If true suppress run title question output
     """
     if not quiet:
-        run_title = get_input("Run title: ")
-        g.change_title(run_title)
         set_label()
-
-
-def begin_postcmd(run_num, quiet):
-    """
-    Return the run number at the end of beginning the run.
-
-    Parameters
-    ----------
-    run_num: str
-      The current run number
-    quiet:
-      Suppress the output to the screen (currently there is not output,
-      but quiet is passed by begin so we have to handle it)
-
-    Returns
-    -------
-    str
-      The run number
-    """
-    return run_num
 
 
 def show_label():
@@ -273,24 +256,15 @@ def show_label():
         print("Comment not set in sample parameters")
 
 
-def end_precmd(quiet):
+def end_precmd():
     """
-    Just before ending the run check that the run title and run information is correct.
-
-    Parameters
-    ----------
-    quiet: bool
-      Do not ask if the run title is correct
+    Just before ending the run check that the run information is correct.
     """
-    if not quiet:
-        run_title = get_input("Is \'{}\' the correct run title (y/n)?".format(g.get_title()))
-        if run_title.lower() == "n":
-            g.change_title(get_input("Run title: "))
-        while True:
-            print("Run information:\n")
-            show_label()
-            label_correct = get_input("Is the run information correct (y/n)?")
-            if label_correct.lower() == "y":
-                break
-            else:
-                set_label()
+    while True:
+        print("Run information:\n")
+        show_label()
+        label_correct = get_input("Is the run information correct (y/n)?")
+        if label_correct.lower() == "y":
+            break
+        else:
+            set_label()

--- a/technique/muon/run_control.py
+++ b/technique/muon/run_control.py
@@ -1,12 +1,11 @@
 from __future__ import print_function
 from genie_python import genie as g
 from six.moves import input
-from time import sleep
 
 
 def get_input(prompt):
     """
-    Get input from the user (allows us to mock it for testing)
+    Get input from the user (allows us to mock more complex functions for testing than patching input).
 
     Parameters
     ----------
@@ -19,6 +18,7 @@ def get_input(prompt):
       The user input
     """
     return input(prompt)
+
 
 # The keys for parameters in the sample parameters dictionary
 name_par = "name"
@@ -115,7 +115,9 @@ def set_geometry_beamline_par(beamline_pars):
         old_geometry = beamline_pars[geometry_par]
     else:
         old_geometry = ""
-    new_geometry = get_input("Geometry (L or T) {}?".format(old_geometry))
+    new_geometry = None
+    while new_geometry not in {"", "L", "T"}:
+        new_geometry = get_input("Geometry (L or T) {}?".format(old_geometry))
     if new_geometry != "":
         g.change_beamline_par(geometry_par, new_geometry)
 
@@ -214,7 +216,6 @@ def begin_precmd(quiet):
         run_title = get_input("Run title: ")
         g.change_title(run_title)
         set_label()
-    sleep(1)
 
 
 def begin_postcmd(run_num, quiet):
@@ -294,4 +295,3 @@ def end_precmd(quiet):
             else:
                 print("SETTING LABEL")
                 set_label()
-    sleep(1)

--- a/technique/muon/run_control.py
+++ b/technique/muon/run_control.py
@@ -11,7 +11,7 @@ def get_input(prompt):
     Parameters
     ----------
     prompt: str
-      The stirng to prompt the user
+      The string to prompt the user
 
     Returns
     -------
@@ -20,16 +20,25 @@ def get_input(prompt):
     """
     return input(prompt)
 
-
+# The keys for parameters in the sample parameters dictionary
 name_par = "name"
 orient_par = "geometry"
 temp_par = "temp_label"
 field_par = "field_label"
-geometry_par = "geometry"
 comment_par = "comments"
+# The key for the geometry parameter in the beamline parameters dictionary
+geometry_par = "geometry"
 
 
 def set_name_sample_par(sample_pars):
+    """
+    Ask the user if the sample parameter (name) is correct and allow them to change it if not.
+
+    Parameters
+    ----------
+    sample_pars: dict
+        The sample parameters that is to contain the name parameter.
+    """
     if name_par in sample_pars:
         old_sample_name = sample_pars[name_par]
     else:
@@ -40,6 +49,14 @@ def set_name_sample_par(sample_pars):
 
 
 def set_orient_sample_par(sample_pars):
+    """
+    Ask the user if the sample parameter (orientation) is correct and allow them to change it if not.
+
+    Parameters
+    ----------
+    sample_pars: dict
+        The sample parameters that is to contain the orientation parameter.
+    """
     if orient_par in sample_pars:
         old_orientation = sample_pars[orient_par]
     else:
@@ -50,6 +67,14 @@ def set_orient_sample_par(sample_pars):
 
 
 def set_temp_sample_par(sample_pars):
+    """
+    Ask the user if the sample parameter (temp) is correct and allow them to change it if not.
+
+    Parameters
+    ----------
+    sample_pars: dict
+        The sample parameters that is to contain the temp parameter.
+    """
     if temp_par in sample_pars:
         old_temp = sample_pars[temp_par]
     else:
@@ -60,6 +85,14 @@ def set_temp_sample_par(sample_pars):
 
 
 def set_field_sample_par(sample_pars):
+    """
+    Ask the user if the sample parameter (field) is correct and allow them to change it if not.
+
+    Parameters
+    ----------
+    sample_pars: dict
+        The sample parameters that is to contain the field parameter.
+    """
     if field_par in sample_pars:
         old_field = sample_pars[field_par]
     else:
@@ -70,6 +103,14 @@ def set_field_sample_par(sample_pars):
 
 
 def set_geometry_beamline_par(beamline_pars):
+    """
+    Ask the user if the sample parameter (geometry) is correct and allow them to change it if not.
+
+    Parameters
+    ----------
+    beamline_pars: dict
+        The sample parameters that is to contain the geometry parameter.
+    """
     if geometry_par in beamline_pars:
         old_geometry = beamline_pars[geometry_par]
     else:
@@ -80,6 +121,9 @@ def set_geometry_beamline_par(beamline_pars):
 
 
 def set_rb_num():
+    """
+    Ask the user if the rb number is correct and allow them to change it if not.
+    """
     old_rb_num = g.get_rb()
     new_rb_num = get_input("RBNo {}?".format(old_rb_num))
     if new_rb_num != "":
@@ -87,6 +131,9 @@ def set_rb_num():
 
 
 def set_users():
+    """
+    Ask the user if the users are correct and allow them to change it if not.
+    """
     old_exp_team = g.get_users()
     new_exp_team = get_input("Experimental Team {}?".format(old_exp_team))
     if new_exp_team != "":
@@ -94,6 +141,14 @@ def set_users():
 
 
 def set_comments_sample_par(sample_pars):
+    """
+    Ask the user if the sample parameter (comments) is correct and allow them to change it if not.
+
+    Parameters
+    ----------
+    sample_pars: dict
+        The sample parameters that is to contain the comments parameter.
+    """
     if comment_par in sample_pars:
         old_comments = sample_pars[comment_par]
     else:
@@ -104,6 +159,28 @@ def set_comments_sample_par(sample_pars):
 
 
 def set_label(sample=True, orient=True, temp=True, field=True, geometry=True, rb_num=True, exp_team=True, comment=True):
+    """
+    Set the run information.
+
+    Parameters
+    ----------
+    sample: bool
+        Whether or not to change the name of the sample
+    orient: bool
+        Whether or not to change the sample parameter: orientation
+    temp: bool
+        Whether  or not to change the sample parameter: temperature
+    field: bool
+        Whether or not to change the sample parameter: field
+    geometry: bool
+        Whether ot not to change the beamline parameter: geometry
+    rb_num: bool
+        Whether or not to change the rb number
+    exp_team: bool
+        Whether or not to change the user
+    comment: bool
+        Whether or not to change the sample parameter: comments
+    """
     sample_pars = g.get_sample_pars()
     if sample:
         set_name_sample_par(sample_pars)
@@ -126,7 +203,7 @@ def set_label(sample=True, orient=True, temp=True, field=True, geometry=True, rb
 
 def begin_precmd(quiet):
     """
-    Set MuSR globals
+    Set the run title and run information.
 
     Parameters
     ----------
@@ -161,6 +238,10 @@ def begin_postcmd(run_num, quiet):
 
 
 def show_label():
+    """
+    Print out the run information including the sample parameters (name, orientation, temperature, field, comments),
+     the rb number, the users and the geometry beamline parameters.
+    """
     sample_pars = g.get_sample_pars()
     beamline_pars = g.get_beamline_pars()
     if name_par in sample_pars:
@@ -179,7 +260,7 @@ def show_label():
         print("Field = {}".format(sample_pars[field_par]))
     else:
         print("Field not set in sample parameters")
-    if geometry_par in geometry_par:
+    if geometry_par in beamline_pars:
         print("Geometry = {}".format(beamline_pars[geometry_par]))
     else:
         print("Geometry not set in beamline parameters")
@@ -193,7 +274,7 @@ def show_label():
 
 def end_precmd(quiet):
     """
-    Just before ending the run check that the run title is correct.
+    Just before ending the run check that the run title and run information is correct.
 
     Parameters
     ----------
@@ -201,16 +282,16 @@ def end_precmd(quiet):
       Do not ask if the run title is correct
     """
     if not quiet:
-        g.get_title()
-        run_title = get_input("Is \'{}\' the correct run title (y/n)?")
+        run_title = get_input("Is \'{}\' the correct run title (y/n)?".format(g.get_title()))
         if run_title.lower() == "n":
             g.change_title(get_input("Run title: "))
         while True:
             print("Run information:\n")
             show_label()
             label_correct = get_input("Is the run information correct (y/n)?")
-            if label_correct.lower() == "n":
+            if label_correct.lower() == "y":
                 break
             else:
+                print("SETTING LABEL")
                 set_label()
     sleep(1)

--- a/technique/muon/tests/test_muon_begin_end.py
+++ b/technique/muon/tests/test_muon_begin_end.py
@@ -5,7 +5,7 @@ os.environ["GENIE_SIMULATE"] = "1"
 # Imports come after to prevent import of genie python not in simulation
 import unittest
 import six.moves
-from technique.muon import run_control
+from technique.muon import muon_begin_end
 from genie_python import genie as g
 if six.PY3:
     from unittest.mock import patch, MagicMock
@@ -21,17 +21,17 @@ class TestRunControl(unittest.TestCase):
     @patch.object(g, 'change_title')
     def test_WHEN_begin_pre_cmd_quiet_THEN_do_not_change_title(self, _):
         # Act
-        run_control.begin_precmd(quiet=True)
+        muon_begin_end.begin_precmd(quiet=True)
 
         # Assert
         self.assertFalse(g.change_title.called, "Should not have called g.change_title(title)")
 
     @patch.object(g, 'change_title')
-    @patch.object(run_control, 'set_label')
+    @patch.object(muon_begin_end, 'set_label')
     @patch('technique.muon.run_control.get_input', return_value="my_title")
     def test_WHEN_begin_pre_cmd_not_quiet_THEN_title_changed(self, _, set_label,  __):
         # Act
-        run_control.begin_precmd(quiet=False)
+        muon_begin_end.begin_precmd(quiet=False)
 
         # Assert
         self.assertTrue(g.change_title.called, "Should have called g.change_title(my_title)")
@@ -42,7 +42,7 @@ class TestRunControl(unittest.TestCase):
     def test_WHEN_set_name_sample_par_to_non_empty_THEN_sample_par_changed(self, _, __):
         # Act
         old_sample_pars = {"name": "oldname"}
-        run_control.set_name_sample_par(old_sample_pars)
+        muon_begin_end.set_name_sample_par(old_sample_pars)
 
         # Assert
         self.assertTrue(g.change_sample_par.called, "Should have called to set sample param")
@@ -52,7 +52,7 @@ class TestRunControl(unittest.TestCase):
     def test_WHEN_set_name_sample_par_to_empty_THEN_sample_par_changed(self, _, __):
         # Act
         old_sample_pars = {"name": "oldname"}
-        run_control.set_name_sample_par(old_sample_pars)
+        muon_begin_end.set_name_sample_par(old_sample_pars)
 
         # Assert
         self.assertFalse(g.change_sample_par.called, "Should not have called to set sample param")
@@ -62,7 +62,7 @@ class TestRunControl(unittest.TestCase):
     def test_WHEN_set_orient_sample_par_to_non_empty_THEN_sample_par_changed(self, _, __):
         # Act
         old_sample_pars = {"geometry": "oldorient"}
-        run_control.set_orient_sample_par(old_sample_pars)
+        muon_begin_end.set_orient_sample_par(old_sample_pars)
 
         # Assert
         self.assertTrue(g.change_sample_par.called, "Should have called to set sample param")
@@ -72,7 +72,7 @@ class TestRunControl(unittest.TestCase):
     def test_WHEN_set_orient_sample_par_to_empty_THEN_sample_par_changed(self, _, __):
         # Act
         old_sample_pars = {"geometry": "oldorient"}
-        run_control.set_orient_sample_par(old_sample_pars)
+        muon_begin_end.set_orient_sample_par(old_sample_pars)
 
         # Assert
         self.assertFalse(g.change_sample_par.called, "Should not have called to set sample param")
@@ -82,7 +82,7 @@ class TestRunControl(unittest.TestCase):
     def test_WHEN_set_temp_sample_par_to_non_empty_THEN_sample_par_changed(self, _, __):
         # Act
         old_sample_pars = {"temp": "oldtemp"}
-        run_control.set_temp_sample_par(old_sample_pars)
+        muon_begin_end.set_temp_sample_par(old_sample_pars)
 
         # Assert
         self.assertTrue(g.change_sample_par.called, "Should have called to set sample param")
@@ -92,7 +92,7 @@ class TestRunControl(unittest.TestCase):
     def test_WHEN_set_temp_sample_par_to_empty_THEN_sample_par_changed(self, _, __):
         # Act
         old_samples_pars = {"temp": "oldTemp"}
-        run_control.set_temp_sample_par(old_samples_pars)
+        muon_begin_end.set_temp_sample_par(old_samples_pars)
 
         # Assert
         self.assertFalse(g.change_sample_par.called, "Should not have called to set sample param")
@@ -102,7 +102,7 @@ class TestRunControl(unittest.TestCase):
     def test_WHEN_set_field_sample_par_to_non_empty_THEN_sample_par_changed(self, _, __):
         # Act
         old_sample_pars = {"field": "oldfield"}
-        run_control.set_field_sample_par(old_sample_pars)
+        muon_begin_end.set_field_sample_par(old_sample_pars)
 
         # Assert
         self.assertTrue(g.change_sample_par.called, "Should have called to set sample param")
@@ -112,7 +112,7 @@ class TestRunControl(unittest.TestCase):
     def test_WHEN_set_field_sample_par_to_empty_THEN_sample_par_changed(self, _, __):
         # Act
         old_sample_pars = {"field": "oldfield"}
-        run_control.set_field_sample_par(old_sample_pars)
+        muon_begin_end.set_field_sample_par(old_sample_pars)
 
         # Assert
         self.assertFalse(g.change_sample_par.called, "Should not have called to set sample param")
@@ -122,7 +122,7 @@ class TestRunControl(unittest.TestCase):
     def test_WHEN_set_geo_beamline_par_to_non_empty_THEN_beamline_par_changed(self, _, __):
         # Act
         old_beamline_pars = {"geo": "oldGeo"}
-        run_control.set_geometry_beamline_par(old_beamline_pars)
+        muon_begin_end.set_geometry_beamline_par(old_beamline_pars)
 
         # Assert
         self.assertTrue(g.change_beamline_par.called, "Should have called to set beamline param")
@@ -132,7 +132,7 @@ class TestRunControl(unittest.TestCase):
     def test_WHEN_set_geo_beamline_par_to_empty_THEN_beamline_par_changed(self, _, __):
         # Act
         old_beamline_pars = {}
-        run_control.set_geometry_beamline_par(old_beamline_pars)
+        muon_begin_end.set_geometry_beamline_par(old_beamline_pars)
 
         # Assert
         self.assertFalse(g.change_beamline_par.called, "Should not have called to set beamline param")
@@ -141,7 +141,7 @@ class TestRunControl(unittest.TestCase):
     @patch('technique.muon.run_control.get_input', return_value="rb_num")
     def test_WHEN_set_rb_num_to_non_empty_THEN_rb_num_changed(self, _, __):
         # Act
-        run_control.set_rb_num()
+        muon_begin_end.set_rb_num()
 
         # Assert
         self.assertTrue(g.change_rb.called, "Should have called to set rb num")
@@ -150,7 +150,7 @@ class TestRunControl(unittest.TestCase):
     @patch('technique.muon.run_control.get_input', return_value="")
     def test_WHEN_set_rb_num_to_non_empty_THEN_rb_num_changed(self, _, __):
         # Act
-        run_control.set_rb_num()
+        muon_begin_end.set_rb_num()
 
         # Assert
         self.assertFalse(g.change_rb.called, "Should not have called to set rb num")
@@ -159,7 +159,7 @@ class TestRunControl(unittest.TestCase):
     @patch('technique.muon.run_control.get_input', return_value="new users")
     def test_WHEN_set_users_to_non_empty_THEN_users_changed(self, _, __):
         # Act
-        run_control.set_users()
+        muon_begin_end.set_users()
 
         # Assert
         self.assertTrue(g.change_users.called, "Should have called to set new users")
@@ -168,7 +168,7 @@ class TestRunControl(unittest.TestCase):
     @patch('technique.muon.run_control.get_input', return_value="")
     def test_WHEN_set_geo_beamline_par_to_non_empty_THEN_beamline_par_changed(self, _, __):
         # Act
-        run_control.set_users()
+        muon_begin_end.set_users()
 
         # Assert
         self.assertFalse(g.change_users.called, "Should not have called to set new users")
@@ -178,7 +178,7 @@ class TestRunControl(unittest.TestCase):
     def test_WHEN_set_comments_sample_par_to_non_empty_THEN_sample_par_changed(self, _, __):
         # Act
         old_sample_pars = {}
-        run_control.set_temp_sample_par(old_sample_pars)
+        muon_begin_end.set_temp_sample_par(old_sample_pars)
 
         # Assert
         self.assertTrue(g.change_sample_par.called, "Should have called to set sample param")
@@ -188,7 +188,7 @@ class TestRunControl(unittest.TestCase):
     def test_WHEN_set_comments_sample_par_to_empty_THEN_sample_par_changed(self, _, __):
         # Act
         old_sample_pars = {}
-        run_control.set_temp_sample_par(old_sample_pars)
+        muon_begin_end.set_temp_sample_par(old_sample_pars)
 
         # Assert
         self.assertFalse(g.change_sample_par.called, "Should not have called to set sample param")
@@ -197,7 +197,7 @@ class TestRunControl(unittest.TestCase):
     @patch('technique.muon.run_control.get_input', return_value="n")
     def test_WHEN_end_pre_cmd_not_quiet_label_correct_THEN_input_called_once(self, _, __):
         # Act
-        run_control.end_precmd(quiet=False)
+        muon_begin_end.end_precmd(quiet=False)
 
         # Assert
         self.assertTrue(g.change_title.called, "Should have called to set title")
@@ -206,7 +206,7 @@ class TestRunControl(unittest.TestCase):
     @patch('technique.muon.run_control.get_input', return_value="y")
     def test_WHEN_end_pre_cmd_not_quiet_label_correct_THEN_input_called_once(self, _, __):
         # Act
-        run_control.end_precmd(quiet=False)
+        muon_begin_end.end_precmd(quiet=False)
 
         # Assert
         self.assertFalse(g.change_title.called, "Should have called to set title")
@@ -218,13 +218,13 @@ class TestRunControl(unittest.TestCase):
                 return "y"
         return "n"
 
-    @patch.object(run_control, "set_label")
+    @patch.object(muon_begin_end, "set_label")
     def test_WHEN_end_pre_cmd_run_information_incorrect_twice_THEN_set_label_called_twice(self, set_label):
         # Arrange
-        run_control.get_input = MagicMock(side_effect=self.end_pre_cmd_get_input)
+        muon_begin_end.get_input = MagicMock(side_effect=self.end_pre_cmd_get_input)
 
         # Act
-        run_control.end_precmd(quiet=False)
+        muon_begin_end.end_precmd(quiet=False)
 
         # Assert
         self.assertEquals(set_label.call_count, 2, "Run information rejected twice so should have asked "

--- a/technique/muon/tests/test_muon_begin_end.py
+++ b/technique/muon/tests/test_muon_begin_end.py
@@ -28,17 +28,34 @@ class TestRunControl(unittest.TestCase):
 
     @patch.object(g, 'change_title')
     @patch.object(muon_begin_end, 'set_label')
-    @patch('technique.muon.run_control.get_input', return_value="my_title")
+    @patch('technique.muon.muon_begin_end.get_input', return_value="my_title")
     def test_WHEN_begin_pre_cmd_not_quiet_THEN_title_changed(self, _, set_label,  __):
         # Act
         muon_begin_end.begin_precmd(quiet=False)
 
         # Assert
-        self.assertTrue(g.change_title.called, "Should have called g.change_title(my_title)")
-        self.assertTrue(set_label.called, "Should have called run_control.set_label()")
+        self.assertTrue(set_label.called, "Should have called muon_begin_end.set_label()")
+
+    @patch.object(g, 'change_title')
+    @patch('technique.muon.muon_begin_end.get_input', return_value="my_title")
+    def test_WHEN_set_label_with_no_change_called_THEN_title_changed(self, _, __):
+        # Act
+        muon_begin_end.set_label(sample=False, orient=False, temp=False, field=False,
+                                 geometry=False, rb_num=False, exp_team=False, comment=False)
+        # Assert
+        self.assertTrue(g.change_title.called, "Should have been called to set the title even if nothing changed")
+
+    @patch.object(g, 'change_title')
+    @patch('technique.muon.muon_begin_end.get_input', return_value="my_sample_par")
+    def test_WHEN_set_label_with_change_called_THEN_title_changed(self, _, __):
+        # Act
+        muon_begin_end.set_label(sample=True, orient=True, temp=True, field=True,
+                                 geometry=False, rb_num=False, exp_team=True, comment=True)
+        # Assert
+        self.assertTrue(g.change_title.called, "Should have been called to set the title even if nothing changed")
 
     @patch.object(g, "change_sample_par")
-    @patch('technique.muon.run_control.get_input', return_value="name")
+    @patch('technique.muon.muon_begin_end.get_input', return_value="name")
     def test_WHEN_set_name_sample_par_to_non_empty_THEN_sample_par_changed(self, _, __):
         # Act
         old_sample_pars = {"name": "oldname"}
@@ -48,8 +65,8 @@ class TestRunControl(unittest.TestCase):
         self.assertTrue(g.change_sample_par.called, "Should have called to set sample param")
 
     @patch.object(g, "change_sample_par")
-    @patch('technique.muon.run_control.get_input', return_value="")
-    def test_WHEN_set_name_sample_par_to_empty_THEN_sample_par_changed(self, _, __):
+    @patch('technique.muon.muon_begin_end.get_input', return_value="")
+    def test_WHEN_set_name_sample_par_to_empty_THEN_sample_par_not_changed(self, _, __):
         # Act
         old_sample_pars = {"name": "oldname"}
         muon_begin_end.set_name_sample_par(old_sample_pars)
@@ -58,7 +75,7 @@ class TestRunControl(unittest.TestCase):
         self.assertFalse(g.change_sample_par.called, "Should not have called to set sample param")
 
     @patch.object(g, "change_sample_par")
-    @patch('technique.muon.run_control.get_input', return_value="orient")
+    @patch('technique.muon.muon_begin_end.get_input', return_value="orient")
     def test_WHEN_set_orient_sample_par_to_non_empty_THEN_sample_par_changed(self, _, __):
         # Act
         old_sample_pars = {"geometry": "oldorient"}
@@ -68,8 +85,8 @@ class TestRunControl(unittest.TestCase):
         self.assertTrue(g.change_sample_par.called, "Should have called to set sample param")
 
     @patch.object(g, "change_sample_par")
-    @patch('technique.muon.run_control.get_input', return_value="")
-    def test_WHEN_set_orient_sample_par_to_empty_THEN_sample_par_changed(self, _, __):
+    @patch('technique.muon.muon_begin_end.get_input', return_value="")
+    def test_WHEN_set_orient_sample_par_to_empty_THEN_sample_par_not_changed(self, _, __):
         # Act
         old_sample_pars = {"geometry": "oldorient"}
         muon_begin_end.set_orient_sample_par(old_sample_pars)
@@ -78,7 +95,7 @@ class TestRunControl(unittest.TestCase):
         self.assertFalse(g.change_sample_par.called, "Should not have called to set sample param")
 
     @patch.object(g, "change_sample_par")
-    @patch('technique.muon.run_control.get_input', return_value="temp")
+    @patch('technique.muon.muon_begin_end.get_input', return_value="temp")
     def test_WHEN_set_temp_sample_par_to_non_empty_THEN_sample_par_changed(self, _, __):
         # Act
         old_sample_pars = {"temp": "oldtemp"}
@@ -88,7 +105,7 @@ class TestRunControl(unittest.TestCase):
         self.assertTrue(g.change_sample_par.called, "Should have called to set sample param")
 
     @patch.object(g, "change_sample_par")
-    @patch('technique.muon.run_control.get_input', return_value="")
+    @patch('technique.muon.muon_begin_end.get_input', return_value="")
     def test_WHEN_set_temp_sample_par_to_empty_THEN_sample_par_changed(self, _, __):
         # Act
         old_samples_pars = {"temp": "oldTemp"}
@@ -98,7 +115,7 @@ class TestRunControl(unittest.TestCase):
         self.assertFalse(g.change_sample_par.called, "Should not have called to set sample param")
 
     @patch.object(g, "change_sample_par")
-    @patch('technique.muon.run_control.get_input', return_value="field")
+    @patch('technique.muon.muon_begin_end.get_input', return_value="field")
     def test_WHEN_set_field_sample_par_to_non_empty_THEN_sample_par_changed(self, _, __):
         # Act
         old_sample_pars = {"field": "oldfield"}
@@ -108,7 +125,7 @@ class TestRunControl(unittest.TestCase):
         self.assertTrue(g.change_sample_par.called, "Should have called to set sample param")
 
     @patch.object(g, "change_sample_par")
-    @patch('technique.muon.run_control.get_input', return_value="")
+    @patch('technique.muon.muon_begin_end.get_input', return_value="")
     def test_WHEN_set_field_sample_par_to_empty_THEN_sample_par_changed(self, _, __):
         # Act
         old_sample_pars = {"field": "oldfield"}
@@ -118,7 +135,7 @@ class TestRunControl(unittest.TestCase):
         self.assertFalse(g.change_sample_par.called, "Should not have called to set sample param")
 
     @patch.object(g, "change_beamline_par")
-    @patch('technique.muon.run_control.get_input', return_value="geo")
+    @patch('technique.muon.muon_begin_end.get_input', return_value="geo")
     def test_WHEN_set_geo_beamline_par_to_non_empty_THEN_beamline_par_changed(self, _, __):
         # Act
         old_beamline_pars = {"geo": "oldGeo"}
@@ -128,8 +145,8 @@ class TestRunControl(unittest.TestCase):
         self.assertTrue(g.change_beamline_par.called, "Should have called to set beamline param")
 
     @patch.object(g, "change_beamline_par")
-    @patch('technique.muon.run_control.get_input', return_value="")
-    def test_WHEN_set_geo_beamline_par_to_empty_THEN_beamline_par_changed(self, _, __):
+    @patch('technique.muon.muon_begin_end.get_input', return_value="")
+    def test_WHEN_set_geo_beamline_par_to_empty_THEN_beamline_par_not_changed(self, _, __):
         # Act
         old_beamline_pars = {}
         muon_begin_end.set_geometry_beamline_par(old_beamline_pars)
@@ -138,7 +155,7 @@ class TestRunControl(unittest.TestCase):
         self.assertFalse(g.change_beamline_par.called, "Should not have called to set beamline param")
 
     @patch.object(g, "change_rb")
-    @patch('technique.muon.run_control.get_input', return_value="rb_num")
+    @patch('technique.muon.muon_begin_end.get_input', return_value="rb_num")
     def test_WHEN_set_rb_num_to_non_empty_THEN_rb_num_changed(self, _, __):
         # Act
         muon_begin_end.set_rb_num()
@@ -147,7 +164,7 @@ class TestRunControl(unittest.TestCase):
         self.assertTrue(g.change_rb.called, "Should have called to set rb num")
 
     @patch.object(g, "change_rb")
-    @patch('technique.muon.run_control.get_input', return_value="")
+    @patch('technique.muon.muon_begin_end.get_input', return_value="")
     def test_WHEN_set_rb_num_to_non_empty_THEN_rb_num_changed(self, _, __):
         # Act
         muon_begin_end.set_rb_num()
@@ -156,7 +173,7 @@ class TestRunControl(unittest.TestCase):
         self.assertFalse(g.change_rb.called, "Should not have called to set rb num")
 
     @patch.object(g, "change_users")
-    @patch('technique.muon.run_control.get_input', return_value="new users")
+    @patch('technique.muon.muon_begin_end.get_input', return_value="new users")
     def test_WHEN_set_users_to_non_empty_THEN_users_changed(self, _, __):
         # Act
         muon_begin_end.set_users()
@@ -165,7 +182,7 @@ class TestRunControl(unittest.TestCase):
         self.assertTrue(g.change_users.called, "Should have called to set new users")
 
     @patch.object(g, "change_users")
-    @patch('technique.muon.run_control.get_input', return_value="")
+    @patch('technique.muon.muon_begin_end.get_input', return_value="")
     def test_WHEN_set_geo_beamline_par_to_non_empty_THEN_beamline_par_changed(self, _, __):
         # Act
         muon_begin_end.set_users()
@@ -174,7 +191,7 @@ class TestRunControl(unittest.TestCase):
         self.assertFalse(g.change_users.called, "Should not have called to set new users")
 
     @patch.object(g, "change_sample_par")
-    @patch('technique.muon.run_control.get_input', return_value="new comment")
+    @patch('technique.muon.muon_begin_end.get_input', return_value="new comment")
     def test_WHEN_set_comments_sample_par_to_non_empty_THEN_sample_par_changed(self, _, __):
         # Act
         old_sample_pars = {}
@@ -184,8 +201,8 @@ class TestRunControl(unittest.TestCase):
         self.assertTrue(g.change_sample_par.called, "Should have called to set sample param")
 
     @patch.object(g, "change_sample_par")
-    @patch('technique.muon.run_control.get_input', return_value="")
-    def test_WHEN_set_comments_sample_par_to_empty_THEN_sample_par_changed(self, _, __):
+    @patch('technique.muon.muon_begin_end.get_input', return_value="")
+    def test_WHEN_set_comments_sample_par_to_empty_THEN_sample_par_not_changed(self, _, __):
         # Act
         old_sample_pars = {}
         muon_begin_end.set_temp_sample_par(old_sample_pars)
@@ -193,23 +210,23 @@ class TestRunControl(unittest.TestCase):
         # Assert
         self.assertFalse(g.change_sample_par.called, "Should not have called to set sample param")
 
-    @patch.object(g, "change_title")
-    @patch('technique.muon.run_control.get_input', return_value="n")
-    def test_WHEN_end_pre_cmd_not_quiet_label_correct_THEN_input_called_once(self, _, __):
+    @patch.object(muon_begin_end, "set_label")
+    @patch('technique.muon.muon_begin_end.get_input', side_effect=["n", "y"])
+    def test_WHEN_end_pre_cmd_called_label_incorrect_THEN_change_title_called(self, mock_set_label, _):
         # Act
-        muon_begin_end.end_precmd(quiet=False)
+        muon_begin_end.end_precmd()
 
         # Assert
-        self.assertTrue(g.change_title.called, "Should have called to set title")
+        self.assertTrue(mock_set_label.called, "Should have called to set the label")
 
     @patch.object(g, "change_title")
-    @patch('technique.muon.run_control.get_input', return_value="y")
-    def test_WHEN_end_pre_cmd_not_quiet_label_correct_THEN_input_called_once(self, _, __):
+    @patch('technique.muon.muon_begin_end.get_input', return_value="y")
+    def test_WHEN_end_pre_cmd_called_label_correct_THEN_change_title_not_called(self, _, __):
         # Act
-        muon_begin_end.end_precmd(quiet=False)
+        muon_begin_end.end_precmd()
 
         # Assert
-        self.assertFalse(g.change_title.called, "Should have called to set title")
+        self.assertFalse(g.change_title.called, "Should not have called to set title")
 
     def end_pre_cmd_get_input(self, input_prompt):
         if input_prompt == "Is the run information correct (y/n)?":
@@ -224,7 +241,7 @@ class TestRunControl(unittest.TestCase):
         muon_begin_end.get_input = MagicMock(side_effect=self.end_pre_cmd_get_input)
 
         # Act
-        muon_begin_end.end_precmd(quiet=False)
+        muon_begin_end.end_precmd()
 
         # Assert
         self.assertEquals(set_label.call_count, 2, "Run information rejected twice so should have asked "

--- a/technique/muon/tests/test_run_control.py
+++ b/technique/muon/tests/test_run_control.py
@@ -41,7 +41,8 @@ class TestRunControl(unittest.TestCase):
     @patch('technique.muon.run_control.get_input', return_value="name")
     def test_WHEN_set_name_sample_par_to_non_empty_THEN_sample_par_changed(self, _, __):
         # Act
-        run_control.set_name_sample_par({"name": "oldname"})
+        old_sample_pars = {"name": "oldname"}
+        run_control.set_name_sample_par(old_sample_pars)
 
         # Assert
         self.assertTrue(g.change_sample_par.called, "Should have called to set sample param")
@@ -50,7 +51,8 @@ class TestRunControl(unittest.TestCase):
     @patch('technique.muon.run_control.get_input', return_value="")
     def test_WHEN_set_name_sample_par_to_empty_THEN_sample_par_changed(self, _, __):
         # Act
-        run_control.set_name_sample_par({"name": "oldname"})
+        old_sample_pars = {"name": "oldname"}
+        run_control.set_name_sample_par(old_sample_pars)
 
         # Assert
         self.assertFalse(g.change_sample_par.called, "Should not have called to set sample param")
@@ -59,7 +61,8 @@ class TestRunControl(unittest.TestCase):
     @patch('technique.muon.run_control.get_input', return_value="orient")
     def test_WHEN_set_orient_sample_par_to_non_empty_THEN_sample_par_changed(self, _, __):
         # Act
-        run_control.set_orient_sample_par({"geometry": "oldorient"})
+        old_sample_pars = {"geometry": "oldorient"}
+        run_control.set_orient_sample_par(old_sample_pars)
 
         # Assert
         self.assertTrue(g.change_sample_par.called, "Should have called to set sample param")
@@ -68,7 +71,8 @@ class TestRunControl(unittest.TestCase):
     @patch('technique.muon.run_control.get_input', return_value="")
     def test_WHEN_set_orient_sample_par_to_empty_THEN_sample_par_changed(self, _, __):
         # Act
-        run_control.set_orient_sample_par({"geometry": "oldorient"})
+        old_sample_pars = {"geometry": "oldorient"}
+        run_control.set_orient_sample_par(old_sample_pars)
 
         # Assert
         self.assertFalse(g.change_sample_par.called, "Should not have called to set sample param")
@@ -77,7 +81,8 @@ class TestRunControl(unittest.TestCase):
     @patch('technique.muon.run_control.get_input', return_value="temp")
     def test_WHEN_set_temp_sample_par_to_non_empty_THEN_sample_par_changed(self, _, __):
         # Act
-        run_control.set_temp_sample_par({"temp": "oldtemp"})
+        old_sample_pars = {"temp": "oldtemp"}
+        run_control.set_temp_sample_par(old_sample_pars)
 
         # Assert
         self.assertTrue(g.change_sample_par.called, "Should have called to set sample param")
@@ -86,7 +91,8 @@ class TestRunControl(unittest.TestCase):
     @patch('technique.muon.run_control.get_input', return_value="")
     def test_WHEN_set_temp_sample_par_to_empty_THEN_sample_par_changed(self, _, __):
         # Act
-        run_control.set_temp_sample_par({"temp": "oldTemp"})
+        old_samples_pars = {"temp": "oldTemp"}
+        run_control.set_temp_sample_par(old_samples_pars)
 
         # Assert
         self.assertFalse(g.change_sample_par.called, "Should not have called to set sample param")
@@ -95,7 +101,8 @@ class TestRunControl(unittest.TestCase):
     @patch('technique.muon.run_control.get_input', return_value="field")
     def test_WHEN_set_field_sample_par_to_non_empty_THEN_sample_par_changed(self, _, __):
         # Act
-        run_control.set_temp_sample_par({"field": "oldfield"})
+        old_sample_pars = {"field": "oldfield"}
+        run_control.set_field_sample_par(old_sample_pars)
 
         # Assert
         self.assertTrue(g.change_sample_par.called, "Should have called to set sample param")
@@ -104,7 +111,8 @@ class TestRunControl(unittest.TestCase):
     @patch('technique.muon.run_control.get_input', return_value="")
     def test_WHEN_set_field_sample_par_to_empty_THEN_sample_par_changed(self, _, __):
         # Act
-        run_control.set_temp_sample_par({"field": "oldfield"})
+        old_sample_pars = {"field": "oldfield"}
+        run_control.set_field_sample_par(old_sample_pars)
 
         # Assert
         self.assertFalse(g.change_sample_par.called, "Should not have called to set sample param")
@@ -113,7 +121,8 @@ class TestRunControl(unittest.TestCase):
     @patch('technique.muon.run_control.get_input', return_value="geo")
     def test_WHEN_set_geo_beamline_par_to_non_empty_THEN_beamline_par_changed(self, _, __):
         # Act
-        run_control.set_geometry_beamline_par({"geo": "oldGeo"})
+        old_beamline_pars = {"geo": "oldGeo"}
+        run_control.set_geometry_beamline_par(old_beamline_pars)
 
         # Assert
         self.assertTrue(g.change_beamline_par.called, "Should have called to set beamline param")
@@ -122,7 +131,8 @@ class TestRunControl(unittest.TestCase):
     @patch('technique.muon.run_control.get_input', return_value="")
     def test_WHEN_set_geo_beamline_par_to_empty_THEN_beamline_par_changed(self, _, __):
         # Act
-        run_control.set_temp_sample_par({"field": "oldGeo"})
+        old_beamline_pars = {}
+        run_control.set_geometry_beamline_par(old_beamline_pars)
 
         # Assert
         self.assertFalse(g.change_beamline_par.called, "Should not have called to set beamline param")
@@ -167,7 +177,8 @@ class TestRunControl(unittest.TestCase):
     @patch('technique.muon.run_control.get_input', return_value="new comment")
     def test_WHEN_set_comments_sample_par_to_non_empty_THEN_sample_par_changed(self, _, __):
         # Act
-        run_control.set_temp_sample_par({"comments": "oldcomments"})
+        old_sample_pars = {}
+        run_control.set_temp_sample_par(old_sample_pars)
 
         # Assert
         self.assertTrue(g.change_sample_par.called, "Should have called to set sample param")
@@ -176,7 +187,8 @@ class TestRunControl(unittest.TestCase):
     @patch('technique.muon.run_control.get_input', return_value="")
     def test_WHEN_set_comments_sample_par_to_empty_THEN_sample_par_changed(self, _, __):
         # Act
-        run_control.set_temp_sample_par({"comments": "oldcomments"})
+        old_sample_pars = {}
+        run_control.set_temp_sample_par(old_sample_pars)
 
         # Assert
         self.assertFalse(g.change_sample_par.called, "Should not have called to set sample param")

--- a/technique/muon/tests/test_run_control.py
+++ b/technique/muon/tests/test_run_control.py
@@ -199,8 +199,8 @@ class TestRunControl(unittest.TestCase):
         # Assert
         self.assertFalse(g.change_title.called, "Should have called to set title")
 
-    def end_pre_cmd_get_input(self, input_promt):
-        if input_promt == "Is the run information correct (y/n)?":
+    def end_pre_cmd_get_input(self, input_prompt):
+        if input_prompt == "Is the run information correct (y/n)?":
             self.get_input_call_count += 1
             if self.get_input_call_count > 2:
                 return "y"

--- a/technique/muon/tests/test_run_control.py
+++ b/technique/muon/tests/test_run_control.py
@@ -1,14 +1,22 @@
+# Set genie python to simulate
+import os
+os.environ["GENIE_SIMULATE"] = "1"
+
+# Imports come after to prevent import of genie python not in simulation
 import unittest
 import six.moves
 from technique.muon import run_control
 from genie_python import genie as g
 if six.PY3:
-    from unittest.mock import patch
+    from unittest.mock import patch, MagicMock
 else:
-    from mock import patch
+    from mock import patch, MagicMock
 
 
 class TestRunControl(unittest.TestCase):
+
+    def setUp(self):
+        self.get_input_call_count = 0
 
     @patch.object(g, 'change_title')
     def test_WHEN_begin_pre_cmd_quiet_THEN_do_not_change_title(self, _):
@@ -19,16 +27,194 @@ class TestRunControl(unittest.TestCase):
         self.assertFalse(g.change_title.called, "Should not have called g.change_title(title)")
 
     @patch.object(g, 'change_title')
-    @patch.object(run_control, 'get_input')
-    def test_WHEN_begin_pre_cmd_not_quiet_THEN_title_changed(self, _, mock_input):
-        # Arrange
-        mock_input.return_value = "my_title"
-
+    @patch.object(run_control, 'set_label')
+    @patch('technique.muon.run_control.get_input', return_value="my_title")
+    def test_WHEN_begin_pre_cmd_not_quiet_THEN_title_changed(self, _, set_label,  __):
         # Act
         run_control.begin_precmd(quiet=False)
 
         # Assert
         self.assertTrue(g.change_title.called, "Should have called g.change_title(my_title)")
+        self.assertTrue(set_label.called, "Should have called run_control.set_label()")
 
-    @patch.object(run_control, 'get_input')
-    def test_WHEN_end_pre_cmd_not_quiet_label_correct_THEN_input_called_once(self, _, ):
+    @patch.object(g, "change_sample_par")
+    @patch('technique.muon.run_control.get_input', return_value="name")
+    def test_WHEN_set_name_sample_par_to_non_empty_THEN_sample_par_changed(self, _, __):
+        # Act
+        run_control.set_name_sample_par({"name": "oldname"})
+
+        # Assert
+        self.assertTrue(g.change_sample_par.called, "Should have called to set sample param")
+
+    @patch.object(g, "change_sample_par")
+    @patch('technique.muon.run_control.get_input', return_value="")
+    def test_WHEN_set_name_sample_par_to_empty_THEN_sample_par_changed(self, _, __):
+        # Act
+        run_control.set_name_sample_par({"name": "oldname"})
+
+        # Assert
+        self.assertFalse(g.change_sample_par.called, "Should not have called to set sample param")
+
+    @patch.object(g, "change_sample_par")
+    @patch('technique.muon.run_control.get_input', return_value="orient")
+    def test_WHEN_set_orient_sample_par_to_non_empty_THEN_sample_par_changed(self, _, __):
+        # Act
+        run_control.set_orient_sample_par({"geometry": "oldorient"})
+
+        # Assert
+        self.assertTrue(g.change_sample_par.called, "Should have called to set sample param")
+
+    @patch.object(g, "change_sample_par")
+    @patch('technique.muon.run_control.get_input', return_value="")
+    def test_WHEN_set_orient_sample_par_to_empty_THEN_sample_par_changed(self, _, __):
+        # Act
+        run_control.set_orient_sample_par({"geometry": "oldorient"})
+
+        # Assert
+        self.assertFalse(g.change_sample_par.called, "Should not have called to set sample param")
+
+    @patch.object(g, "change_sample_par")
+    @patch('technique.muon.run_control.get_input', return_value="temp")
+    def test_WHEN_set_temp_sample_par_to_non_empty_THEN_sample_par_changed(self, _, __):
+        # Act
+        run_control.set_temp_sample_par({"temp": "oldtemp"})
+
+        # Assert
+        self.assertTrue(g.change_sample_par.called, "Should have called to set sample param")
+
+    @patch.object(g, "change_sample_par")
+    @patch('technique.muon.run_control.get_input', return_value="")
+    def test_WHEN_set_temp_sample_par_to_empty_THEN_sample_par_changed(self, _, __):
+        # Act
+        run_control.set_temp_sample_par({"temp": "oldTemp"})
+
+        # Assert
+        self.assertFalse(g.change_sample_par.called, "Should not have called to set sample param")
+
+    @patch.object(g, "change_sample_par")
+    @patch('technique.muon.run_control.get_input', return_value="field")
+    def test_WHEN_set_field_sample_par_to_non_empty_THEN_sample_par_changed(self, _, __):
+        # Act
+        run_control.set_temp_sample_par({"field": "oldfield"})
+
+        # Assert
+        self.assertTrue(g.change_sample_par.called, "Should have called to set sample param")
+
+    @patch.object(g, "change_sample_par")
+    @patch('technique.muon.run_control.get_input', return_value="")
+    def test_WHEN_set_field_sample_par_to_empty_THEN_sample_par_changed(self, _, __):
+        # Act
+        run_control.set_temp_sample_par({"field": "oldfield"})
+
+        # Assert
+        self.assertFalse(g.change_sample_par.called, "Should not have called to set sample param")
+
+    @patch.object(g, "change_beamline_par")
+    @patch('technique.muon.run_control.get_input', return_value="geo")
+    def test_WHEN_set_geo_beamline_par_to_non_empty_THEN_beamline_par_changed(self, _, __):
+        # Act
+        run_control.set_geometry_beamline_par({"geo": "oldGeo"})
+
+        # Assert
+        self.assertTrue(g.change_beamline_par.called, "Should have called to set beamline param")
+
+    @patch.object(g, "change_beamline_par")
+    @patch('technique.muon.run_control.get_input', return_value="")
+    def test_WHEN_set_geo_beamline_par_to_empty_THEN_beamline_par_changed(self, _, __):
+        # Act
+        run_control.set_temp_sample_par({"field": "oldGeo"})
+
+        # Assert
+        self.assertFalse(g.change_beamline_par.called, "Should not have called to set beamline param")
+
+    @patch.object(g, "change_rb")
+    @patch('technique.muon.run_control.get_input', return_value="rb_num")
+    def test_WHEN_set_rb_num_to_non_empty_THEN_rb_num_changed(self, _, __):
+        # Act
+        run_control.set_rb_num()
+
+        # Assert
+        self.assertTrue(g.change_rb.called, "Should have called to set rb num")
+
+    @patch.object(g, "change_rb")
+    @patch('technique.muon.run_control.get_input', return_value="")
+    def test_WHEN_set_rb_num_to_non_empty_THEN_rb_num_changed(self, _, __):
+        # Act
+        run_control.set_rb_num()
+
+        # Assert
+        self.assertFalse(g.change_rb.called, "Should not have called to set rb num")
+
+    @patch.object(g, "change_users")
+    @patch('technique.muon.run_control.get_input', return_value="new users")
+    def test_WHEN_set_users_to_non_empty_THEN_users_changed(self, _, __):
+        # Act
+        run_control.set_users()
+
+        # Assert
+        self.assertTrue(g.change_users.called, "Should have called to set new users")
+
+    @patch.object(g, "change_users")
+    @patch('technique.muon.run_control.get_input', return_value="")
+    def test_WHEN_set_geo_beamline_par_to_non_empty_THEN_beamline_par_changed(self, _, __):
+        # Act
+        run_control.set_users()
+
+        # Assert
+        self.assertFalse(g.change_users.called, "Should not have called to set new users")
+
+    @patch.object(g, "change_sample_par")
+    @patch('technique.muon.run_control.get_input', return_value="new comment")
+    def test_WHEN_set_comments_sample_par_to_non_empty_THEN_sample_par_changed(self, _, __):
+        # Act
+        run_control.set_temp_sample_par({"comments": "oldcomments"})
+
+        # Assert
+        self.assertTrue(g.change_sample_par.called, "Should have called to set sample param")
+
+    @patch.object(g, "change_sample_par")
+    @patch('technique.muon.run_control.get_input', return_value="")
+    def test_WHEN_set_comments_sample_par_to_empty_THEN_sample_par_changed(self, _, __):
+        # Act
+        run_control.set_temp_sample_par({"comments": "oldcomments"})
+
+        # Assert
+        self.assertFalse(g.change_sample_par.called, "Should not have called to set sample param")
+
+    @patch.object(g, "change_title")
+    @patch('technique.muon.run_control.get_input', return_value="n")
+    def test_WHEN_end_pre_cmd_not_quiet_label_correct_THEN_input_called_once(self, _, __):
+        # Act
+        run_control.end_precmd(quiet=False)
+
+        # Assert
+        self.assertTrue(g.change_title.called, "Should have called to set title")
+
+    @patch.object(g, "change_title")
+    @patch('technique.muon.run_control.get_input', return_value="y")
+    def test_WHEN_end_pre_cmd_not_quiet_label_correct_THEN_input_called_once(self, _, __):
+        # Act
+        run_control.end_precmd(quiet=False)
+
+        # Assert
+        self.assertFalse(g.change_title.called, "Should have called to set title")
+
+    def end_pre_cmd_get_input(self, input_promt):
+        if input_promt == "Is the run information correct (y/n)?":
+            self.get_input_call_count += 1
+            if self.get_input_call_count > 2:
+                return "y"
+        return "n"
+
+    @patch.object(run_control, "set_label")
+    def test_WHEN_end_pre_cmd_run_information_incorrect_twice_THEN_set_label_called_twice(self, set_label):
+        # Arrange
+        run_control.get_input = MagicMock(side_effect=self.end_pre_cmd_get_input)
+
+        # Act
+        run_control.end_precmd(quiet=False)
+
+        # Assert
+        self.assertEquals(set_label.call_count, 2, "Run information rejected twice so should have asked "
+                                                   "user to set the labels 2 times")
+

--- a/technique/muon/tests/test_run_control.py
+++ b/technique/muon/tests/test_run_control.py
@@ -1,0 +1,34 @@
+import unittest
+import six.moves
+from technique.muon import run_control
+from genie_python import genie as g
+if six.PY3:
+    from unittest.mock import patch
+else:
+    from mock import patch
+
+
+class TestRunControl(unittest.TestCase):
+
+    @patch.object(g, 'change_title')
+    def test_WHEN_begin_pre_cmd_quiet_THEN_do_not_change_title(self, _):
+        # Act
+        run_control.begin_precmd(quiet=True)
+
+        # Assert
+        self.assertFalse(g.change_title.called, "Should not have called g.change_title(title)")
+
+    @patch.object(g, 'change_title')
+    @patch.object(run_control, 'get_input')
+    def test_WHEN_begin_pre_cmd_not_quiet_THEN_title_changed(self, _, mock_input):
+        # Arrange
+        mock_input.return_value = "my_title"
+
+        # Act
+        run_control.begin_precmd(quiet=False)
+
+        # Assert
+        self.assertTrue(g.change_title.called, "Should have called g.change_title(my_title)")
+
+    @patch.object(run_control, 'get_input')
+    def test_WHEN_end_pre_cmd_not_quiet_label_correct_THEN_input_called_once(self, _, ):


### PR DESCRIPTION
THIS MUST BE REVIEWED BY SOMEONE FROM COMPUTING

### Description of work

Added the relevant pre_cmd functions to hook into begin and end commands to check run information and titles and allow the user to changed them where required.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4913

### Acceptance Criteria

- [ ] On using g.begin() where I have loaded the relevant muon instrument script, I am prompted for the run title
- [ ] On using g.end() where I have loaded the relevant muon instrument script, I am asked to confirm that the run title is correct
- [ ] IBEX provides the same level of functionality as the muon-specific BEGIN and END commands in OpenGenie (Please see emu_routines.gcl on the isis experimental control shares in muon migration)
- [ ] The IBEX genie_python and instrument script documentation are updated to document the muon-specific behaviour.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?