### PR TITLE
Ticket5102 add quiet argument to end command

### DIFF
--- a/technique/muon/muon_begin_end.py
+++ b/technique/muon/muon_begin_end.py
@@ -258,11 +258,14 @@ def end_precmd(**pars):
     """
     Just before ending the run check that the run information is correct.
     """
-    while True:
-        print("Run information:\n")
-        show_label()
-        label_correct = get_input("Is the run information correct (y/n)?")
-        if label_correct.lower() == "y":
-            break
-        else:
-            set_label()
+    
+    if 'quiet' in pars:
+        if not pars['quiet']:
+            while True:
+                print("Run information:\n")
+                show_label()
+                label_correct = get_input("Is the run information correct (y/n)?")
+                if label_correct.lower() == "y":
+                    break
+                else:
+                    set_label()

--- a/technique/muon/muon_begin_end.py
+++ b/technique/muon/muon_begin_end.py
@@ -213,9 +213,8 @@ def begin_precmd(**pars):
     quiet: bool
       If true suppress run title question output
     """
-    if 'quiet' in pars:
-        if not pars['quiet']:
-            set_label()
+    if not pars.get('quiet', False):
+        set_label()
 
 
 def show_label():
@@ -257,15 +256,19 @@ def show_label():
 def end_precmd(**pars):
     """
     Just before ending the run check that the run information is correct.
+
+    Parameters
+    ----------
+    quiet: bool
+      If true suppress run title question output
     """
-    
-    if 'quiet' in pars:
-        if not pars['quiet']:
-            while True:
-                print("Run information:\n")
-                show_label()
-                label_correct = get_input("Is the run information correct (y/n)?")
-                if label_correct.lower() == "y":
-                    break
-                else:
-                    set_label()
+
+    if not pars.get('quiet', False):
+        while True:
+            print("Run information:\n")
+            show_label()
+            label_correct = get_input("Is the run information correct (y/n)?")
+            if label_correct.lower() == "y":
+                break
+            else:
+                set_label()

--- a/technique/muon/tests/test_muon_begin_end.py
+++ b/technique/muon/tests/test_muon_begin_end.py
@@ -246,3 +246,19 @@ class TestRunControl(unittest.TestCase):
         # Assert
         self.assertEqual(set_label.call_count, 2, "Run information rejected twice so should have asked "
                                                    "user to set the labels 2 times")
+
+    @patch('technique.muon.muon_begin_end.get_input', return_value="y")
+    def test_WHEN_end_pre_cmd_called_WITH_quiet_set_to_false_THEN_change_title_called(self, mock_get_input):
+        # Act
+        muon_begin_end.end_precmd(quiet=False)
+
+        # Assert
+        self.assertGreater(mock_get_input.call_count, 0, "Set_label method called")
+
+    @patch('technique.muon.muon_begin_end.get_input', return_value="y")
+    def test_WHEN_end_pre_cmd_called_WITH_quiet_set_to_true_THEN_change_title_not_called(self, mock_get_input):
+        # Act
+        muon_begin_end.end_precmd(quiet=True)
+
+        # Assert
+        self.assertEqual(mock_get_input.call_count, 0, "Set_label method NOT called")


### PR DESCRIPTION
Edited pre and post commands to make use of new `quiet` argument.

Added tests for new functionality.

See ticket [5102](https://github.com/ISISComputingGroup/IBEX/issues/5102) for details.