### PR TITLE
Removed default Codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,3 @@
-* @rprospero @DiegoAlbaVenero
-
 # Any changes to instrument code should be reviewed by an instrument
 # scientist on that beam line
 /instrument/larmor @rprospero


### PR DESCRIPTION
As a developer I do not want it to look like someone is reviewing a ticket that they aren't. Setting the code owners automatically adds developers as a reviewer. This is fine when done for some folders where the code does belong to someone but we don't need a default.

To test confirm that subsequent PRs (e.g https://github.com/ISISNeutronMuon/InstrumentScripts/pull/54) do not have a default reviewer. Once this is merged delete https://github.com/ISISNeutronMuon/InstrumentScripts/pull/54 without merging and remove associated branch.