### PR TITLE
Ticket5284

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dot.pdf
 *.dot
 *.egg-info 
+*__pycache__/
 .idea/
 /doc/build
 /doc/source/scans/*.dat

--- a/technique/muon/background_plot.py
+++ b/technique/muon/background_plot.py
@@ -16,7 +16,6 @@ from genie_python import genie as g
 from genie_python.genie_cachannel_wrapper import CaChannelWrapper, CaChannelException, UnableToConnectToPVException
 from genie_python.matplotlib_backend.ibex_web_backend import set_up_plot_default, SECONDARY_WEB_PORT
 from requests import head, ConnectionError
-import numpy as np
 
 # Default Figure name for the plot
 DEFAULT_FIGURE_NAME = "Background Plot"
@@ -87,10 +86,8 @@ class BackgroundPlot(object):
 
         self.set_up_plot()
 
-        print(np.shape(self.data))
         if self.saved_data_matches_current_dataset():
             self.load_data_from_save()
-            print(np.shape(self.data))
         else:
             self.start_new_data_file()
 

--- a/technique/muon/background_plot.py
+++ b/technique/muon/background_plot.py
@@ -134,18 +134,11 @@ class BackgroundPlot(object):
         """
         Imports data from the save file
         """
-
-        data_x = self.data_x
-        print(data_x)
-        data = self.data
-
+        # Copy nested list structure from first point
+        loaded_data = [list() for x in range(len(self.data))]
         loaded_data_x = []
 
-        # Copy nested list structure
-        loaded_data = [list() for x in range(len(self.data))]
-
         with open(SAVE_FILE, 'r') as csvfile:
-
             file_without_header = filter(lambda row: row if not row.startswith('#') else '', csvfile)
             reader = csv.reader(file_without_header)
 
@@ -155,37 +148,13 @@ class BackgroundPlot(object):
                 for dataset, restored_dataset in zip(loaded_data, points[1:]):
                     dataset.append(float(restored_dataset))
 
-        #loaded_data.extend(self.data)
-        
+        # Add first points already plotted
         for dataset, first_point in zip(loaded_data, self.data):
             dataset.extend(first_point)
-        
         loaded_data_x.extend(self.data_x)
-
-        print(loaded_data_x)
-        print(loaded_data)
 
         self.data = loaded_data
         self.data_x = loaded_data_x
-
-        # chronological_order = np.argsort(data_x)
-
-        # self.data_x = data_x[chronological_order].tolist()
-        # self.data = np.asarray(data)[:, chronological_order].tolist()
-
-        # restored_dataset = np.genfromtxt(SAVE_FILE, comments='#', converters={0: lambda x: datetime.fromisoformat(str(x))}, delimiter=',', dtype=None)
-        # #restored_dataset = np.genfromtxt(SAVE_FILE, comments='#', delimiter=',', usecols=[1, 2], converters={0: datetime.fromisoformat})
-
-        # print(restored_dataset[:, 0])
-
-        # # Re-add first data points to start of array
-        # np.append(restored_dataset, first_points)
-        # restored_dataset.sort(axis=0)
-
-        # x_dim, data = np.split(restored_dataset, [1, ])
-
-        # self.data_x = x_dim
-        # self.data = data
 
     def _update(self, frame, *fargs):
         """
@@ -219,7 +188,6 @@ class BackgroundPlot(object):
             List of matplotlib artists
         """
         if self.should_clear_plot():
-            print('clearing plot')
             self.clear_plot()
             self.start_new_data_file()
         else:
@@ -254,7 +222,6 @@ class BackgroundPlot(object):
         self.data_x.append(point[0])
         for data_set, point in zip(self.data, point[1:]):
             data_set.append(point)
-
 
     def update_figure(self):
         """
@@ -310,7 +277,7 @@ class BackgroundPlot(object):
         True if the saved dataset dimensions match, else False
 
         Should be overloaded for desired behaviour
-        
+
         Returns
         -------
         False, data is never loaded from disc
@@ -325,7 +292,6 @@ class BackgroundPlot(object):
         -------
 
         """
-        print('3')
         self._first_point()
         self.update_figure()
 
@@ -459,7 +425,6 @@ class BackgroundBlockPlot(BackgroundPlot):
                 run_state = self._get_pv_with_timeout(self._run_state_pv, to_string=True)
                 if run_state == 'RUNNING':
                     self.current_run_number = num
-                    print('should clear plot')
                     return True
             return False
         except (CaChannelException, UnableToConnectToPVException):
@@ -492,16 +457,13 @@ class BackgroundBlockPlot(BackgroundPlot):
 
         saved_run_number = run_number.replace("# run_number=", "")
 
-        print(int(saved_run_number))
-        print(int(self.current_run_number))
-
         if int(saved_run_number) == int(self.current_run_number) and saved_dataset_dims == current_dataset_dims:
-            print('dataset matches')
+            print("Dataset matches - loading values from save")
             dataset_matches = True
         else:
-            print('dataset doesnt match')
+            print("Dataset doesn't match - do not load from save")
             dataset_matches = False
-        
+
         return dataset_matches
 
     def start_new_data_file(self):

--- a/technique/muon/background_plot.py
+++ b/technique/muon/background_plot.py
@@ -27,6 +27,7 @@ BLOCK_PREFIX = "CS:SB:"
 # Name of file which data points are saved to
 SAVE_FILE = os.path.join(r"C:\\", "Instrument", "var", "tmp", "background_plot_data_{ioc_number:02d}.csv")
 
+
 class BackgroundPlot(object):
     """
     Create a background plot of some points which update
@@ -140,13 +141,13 @@ class BackgroundPlot(object):
             file_without_header = filter(lambda row: row if not row.startswith('#') else '', csvfile)
             reader = csv.reader(file_without_header)
 
-            for points in reader:
-                loaded_data_x.append(datetime.fromisoformat(points[0]))
-                
-                for dataset, restored_dataset in zip(loaded_data, points[1:]):
+            for row in reader:
+                loaded_data_x.append(datetime.fromisoformat(row[0]))
+
+                for dataset, restored_dataset in zip(loaded_data, row[1:]):
                     dataset.append(float(restored_dataset))
 
-        # Add first points already plotted
+        # Add first points already taken
         for dataset, first_point in zip(loaded_data, self.data):
             dataset.extend(first_point)
         loaded_data_x.extend(self.data_x)
@@ -233,7 +234,7 @@ class BackgroundPlot(object):
         for data_set, line in zip(self.data, self.lines):
             line.set_data(self.data_x, data_set)
         self.figure.gca().relim()
-        self.figure.gca().set_xlim(left=min(self.data_x), right=max(self.data_x) + timedelta(seconds=0.5))
+        self.figure.gca().set_xlim(left=self.data_x[0], right=self.data_x[-1] + timedelta(seconds=0.5))
         self.figure.gca().autoscale_view()
 
         return self.lines

--- a/technique/muon/background_plot.py
+++ b/technique/muon/background_plot.py
@@ -34,6 +34,8 @@ class BackgroundPlot(object):
     """
 
     def __init__(self, interval, figure_name=DEFAULT_FIGURE_NAME, ioc_number=None):
+        if ioc_number is None:
+            raise ValueError("IOC number must be set")
 
         set_up_plot_default(is_primary=False, should_open_ibex_window_on_show=False)
 

--- a/technique/muon/background_plot.py
+++ b/technique/muon/background_plot.py
@@ -330,8 +330,11 @@ class BackgroundBlockPlot(BackgroundPlot):
 
         interval: float
             interval at which block should be plotted in seconds
+
+        ioc_number: int
+            The number of the BGRSCRPT IOC which has spawned this class.        
         """
-        super(BackgroundBlockPlot, self).__init__(interval, "{} Plot".format(y_axis_label), ioc_number=1)
+        super(BackgroundBlockPlot, self).__init__(interval, "{} Plot".format(y_axis_label), ioc_number=ioc_number)
         self._run_state_pv = g.prefix_pv_name(DAE_PVS_LOOKUP["runstate"])
         self._run_number_pv = g.prefix_pv_name(DAE_PVS_LOOKUP["runnumber"])
         self._pv_names = []


### PR DESCRIPTION
### Instrument(s)

Muons

### Story/Acceptance criteria

- [ ] Data taken by the background plot can be saved to a file
- [ ] File can be reloaded on IOC start to give a persistant data set
- [ ] The data set is discarded on a change of run number
- [ ] Multiple BGRSCRPT IOCs can be saving/loading data independently

### Description of work

Added CSV reader/writer, with logic to check whether the data matches the first data points collected after IOC boots.

The skeleton structure has been added to the `BackgroundPlot` class, with implementation details added in `BackgroundBlockPlot`.

### Issue/Ticket Reference

https://github.com/ISISComputingGroup/IBEX/issues/5284

### Tests

Describing the testing undertaken for this PR

### To test

Follow instructions to make a background plotting script here: https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Background-Script-IOC

---

#### Code Review

- [ ] Is the story/acceptance criteria fulfilled?
- [ ] Is the code of an acceptable quality?
- [ ] Are the tests sufficient?
- [ ] Do the changes function as described and is it robust?
- [ ] Are the changes able to work across all intended instruments?

### Final Steps
- [ ] Are there any changes to instrument configurations required?
- [ ] Are there any changes to instrument scripts required, e.g. change on script signature, default argument and have these been communicated?
- [ ] Does the script need to be deployed onto the instrument?
