### PR TITLE
Created send_tcpip to help talk directly to hardware

### DIFF
--- a/general/utilities/__init__.py
+++ b/general/utilities/__init__.py
@@ -1,0 +1,3 @@
+"""Utilities are functions that could be useful to instruments but are not directly related to controlling IBEX
+
+"""

--- a/general/utilities/hardware_communication.py
+++ b/general/utilities/hardware_communication.py
@@ -1,0 +1,28 @@
+import socket
+from contextlib import closing
+
+
+def send_tcpip(message, host, port, reply):
+    """
+    Sends a message to tcp port on host.
+
+    Args:
+        message (string):  the message to send
+        host    (string):  the host address to use
+        port    (integer): the tcpip port to use
+        reply   (bool):    whether to wait for a reply
+
+    Returns:
+        None if reply False else the bytes that the server sends back
+    """
+    try:
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+            s.connect((host, port))
+            s.sendall(bytes(message, "utf-8"))
+            if reply:
+                data = s.recv(1024)
+            else:
+                data = None
+        return data
+    except Exception as e:
+        raise Exception("Could not send message to tcp port: {}".format(e))


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/5457

Effectively just copied from `genie_python` and fixed for python 3. Hard to write tests as very dependent on external server.

I tested by running
```python
#!/usr/bin/env python3

import socket

HOST = '127.0.0.1'  # Standard loopback interface address (localhost)
PORT = 65432        # Port to listen on (non-privileged ports are > 1023)

with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
    s.bind((HOST, PORT))
    s.listen()
    conn, addr = s.accept()
    with conn:
        print('Connected by', addr)
        while True:
            data = conn.recv(1024)
            if not data:
                break
            conn.sendall(data)
```
In a separate process and then calling `print(send_tcpip("hi", '127.0.0.1', 65432, True))` and confirming that "hi" is returned. 

---

#### Code Review

- [ ] Is the story/acceptance criteria fulfilled?
- [ ] Is the code of an acceptable quality?
- [ ] Are the tests sufficient?
- [ ] Do the changes function as described and is it robust?
- [ ] Are the changes able to work across all intended instruments?

### Final Steps
- [ ] Are there any changes to instrument configurations required?
- [ ] Are there any changes to instrument scripts required, e.g. change on script signature, default argument and have these been communicated?
- [ ] Does the script need to be deployed onto the instrument?
