### PR TITLE
Remove populate from instruments which was missed in original remove popluate

### DIFF
--- a/instrument/crisp/scans.py
+++ b/instrument/crisp/scans.py
@@ -97,5 +97,4 @@ scan = _scan_instance.scan
 ascan = _scan_instance.ascan
 dscan = _scan_instance.dscan
 rscan = _scan_instance.rscan
-populate = _scan_instance.populate
 last_scan = _scan_instance.last_scan

--- a/instrument/demo/scans.py
+++ b/instrument/demo/scans.py
@@ -132,5 +132,4 @@ scan = _scan_instance.scan
 ascan = _scan_instance.ascan
 dscan = _scan_instance.dscan
 rscan = _scan_instance.rscan
-populate = _scan_instance.populate
 last_scan = _scan_instance.last_scan

--- a/instrument/surf/scans.py
+++ b/instrument/surf/scans.py
@@ -108,5 +108,4 @@ scan = _scan_instance.scan
 ascan = _scan_instance.ascan
 dscan = _scan_instance.dscan
 rscan = _scan_instance.rscan
-populate = _scan_instance.populate
 last_scan = _scan_instance.last_scan


### PR DESCRIPTION
### Instrument(s)

SURF and CRISP

### Story/Acceptance criteria

Populate was removed in favour of `b.` but we missed that instruments import this as a function in their scripts so this corrects that

### Description of work

Remove populate references

### Issue/Ticket Reference

None found during debug

### Tests

do `from instrument.<instrument> import *`
where <instrument> is surf or crisp or demo

---

#### Code Review

- [ ] Is the story/acceptance criteria fulfilled?
- [ ] Is the code of an acceptable quality?
- [ ] Are the tests sufficient?
- [ ] Do the changes function as described and is it robust?
- [ ] Are the changes able to work across all intended instruments?

### Final Steps
- [ ] Are there any changes to instrument configurations required?
- [ ] Are there any changes to instrument scripts required, e.g. change on script signature, default argument and have these been communicated?
- [ ] Does the script need to be deployed onto the instrument?
