### PR TITLE
5620: Moved Motion.get_units to genie_epics_api

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2020-08-20    <mihai.stavila@stfc.ac.uk>
+
+    * general/scans/motion.py (Motion.get_units): Moved to the
+    genie_epics_api as get_block_units(), added to g.cget().
+
 2019-10-30    <adam.washington@stfc.ac.uk>
 
 	* general/scans/defaults.py (Defaults.get_units): Check that a

--- a/general/scans/motion.py
+++ b/general/scans/motion.py
@@ -219,7 +219,7 @@ def get_motion(motion_or_block_name):
     if isinstance(motion_or_block_name, Motion):
         motion = motion_or_block_name
     elif isinstance(motion_or_block_name, (str, text_type)):
-        motion = BlockMotion(motion_or_block_name, g.cget(motion_or_block_name)["units"])
+        motion = BlockMotion(motion_or_block_name, g.get_block_units(motion_or_block_name))
     else:
         raise TypeError("Cannot run scan on axis {}. Try a string or a motion object instead.".format(
             motion_or_block_name))

--- a/general/scans/motion.py
+++ b/general/scans/motion.py
@@ -228,6 +228,7 @@ def get_motion(motion_or_block_name):
 
 def get_units(block_name):
     """
+    This method is deprecated and will be removed, please use g.get_block_units(block_name).
     Get the physical measurement units associated with a block name.
 
     Parameters

--- a/general/scans/motion.py
+++ b/general/scans/motion.py
@@ -219,31 +219,8 @@ def get_motion(motion_or_block_name):
     if isinstance(motion_or_block_name, Motion):
         motion = motion_or_block_name
     elif isinstance(motion_or_block_name, (str, text_type)):
-        motion = BlockMotion(motion_or_block_name, get_units(motion_or_block_name))
+        motion = BlockMotion(motion_or_block_name, g.cget(motion_or_block_name)["units"])
     else:
         raise TypeError("Cannot run scan on axis {}. Try a string or a motion object instead.".format(
             motion_or_block_name))
     return motion
-
-
-def get_units(block_name):
-    """
-    Get the physical measurement units associated with a block name.
-
-    Parameters
-    ----------
-    block_name: name of the block
-
-    Returns
-    -------
-    units of the block
-    """
-    pv_name = g.adv.get_pv_from_block(block_name)
-    if "." in pv_name:
-        # Remove any headers
-        pv_name = pv_name.split(".")[0]
-    unit_name = pv_name + ".EGU"
-    # pylint: disable=protected-access
-    if g._genie_api.pv_exists(unit_name):
-        return g.get_pv(unit_name)
-    return ""

--- a/general/scans/motion.py
+++ b/general/scans/motion.py
@@ -224,3 +224,19 @@ def get_motion(motion_or_block_name):
         raise TypeError("Cannot run scan on axis {}. Try a string or a motion object instead.".format(
             motion_or_block_name))
     return motion
+
+
+def get_units(block_name):
+    """
+    Get the physical measurement units associated with a block name.
+
+    Parameters
+    ----------
+    block_name: name of the block
+
+    Returns
+    -------
+    units of the block
+    """
+    print("This method is deprecated and will be removed, please use g.get_block_units(block_name)")
+    return g.get_block_units(block_name)


### PR DESCRIPTION
### Instrument(s)

general/scans/motion.py

### Story/Acceptance criteria

- As an instrument scientist I want the units of a block to be accessible through the api, this is needed when creating graphs with units on (and probably other places too)

### Description of work

Units for a block are now accessible directly through the API.
Moved the `Motion/get_units` function to `genie_epics_api`, renamed to `get_block_units` to be used in `get_block_data` for `g.cget()` 

### Issue/Ticket Reference

https://github.com/ISISComputingGroup/IBEX/issues/5620

### Tests

Block units are displayed in the output dictionary from `g.cget("<blockname>")`

### To test

In IBEX GUI Scripting perspective run the `g.cget()` command on a block. The block's unit (if it has one) should be displayed under the value e.g. `('unit', 'Hz'),`. If block does not have a unit, it will be an empty string e.g `('unit', ''),`.

---

#### Code Review

- [ ] Is the story/acceptance criteria fulfilled?
- [ ] Is the code of an acceptable quality?
- [ ] Are the tests sufficient?
- [ ] Do the changes function as described and is it robust?
- [ ] Are the changes able to work across all intended instruments?

### Final Steps
- [ ] Are there any changes to instrument configurations required?
- [ ] Are there any changes to instrument scripts required, e.g. change on script signature, default argument and have these been communicated?
- [ ] Does the script need to be deployed onto the instrument?
