### PR TITLE
Ticket5710: Restart IOC when in alarm

### DIFF
--- a/general/utilities/restart_ioc_when_pv_in_alarm.py
+++ b/general/utilities/restart_ioc_when_pv_in_alarm.py
@@ -1,15 +1,7 @@
-import sys
-import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.environ["KIT_ROOT"], "ISIS", "inst_servers", "master")))
 from genie_python import genie as g
 from time import sleep
-from server_common.helpers import register_ioc_start
 from typing import List
 from threading import Thread
-
-IOC_TO_RUN_IN = "BGRSCRPT_02"
-register_ioc_start(IOC_TO_RUN_IN)
-g.set_instrument(None)
 
 
 def restart_ioc_when_pv_in_alarm(block_to_monitor: str, iocs_to_restart: List[str], error_states: List[str],
@@ -22,13 +14,12 @@ def restart_ioc_when_pv_in_alarm(block_to_monitor: str, iocs_to_restart: List[st
     :param wait_between_restarts: The time (seconds) to wait between restarts
     :param wait_for_polling: The time (seconds) to wait between polling for the block's value
     """
-
-    a = Thread(target=_loop, args=[block_to_monitor, error_states, iocs_to_restart, wait_between_restarts, wait_for_polling])
+    a = Thread(target=_poll_and_restart_ioc_in_alarm, args=[block_to_monitor, error_states, iocs_to_restart, wait_between_restarts, wait_for_polling])
     a.setDaemon(True)
     a.start()
 
 
-def _loop(block_to_monitor, error_states, iocs_to_restart, wait_between_restarts, wait_for_polling):
+def _poll_and_restart_ioc_in_alarm(block_to_monitor, error_states, iocs_to_restart, wait_between_restarts, wait_for_polling):
     while True:
         block_details = g.cget(block_to_monitor)
         if block_details["value"] in error_states:

--- a/general/utilities/restart_ioc_when_pv_in_alarm.py
+++ b/general/utilities/restart_ioc_when_pv_in_alarm.py
@@ -1,0 +1,30 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.environ["KIT_ROOT"], "ISIS", "inst_servers", "master")))
+
+from genie_python import genie as g
+from time import sleep
+from server_common.helpers import register_ioc_start
+
+IOC_TO_RUN_IN = "BGRSCRPT_02"
+#BLOCK_TO_MONITOR = "SIMPLE_VAL"
+#IOC_TO_RESTART = ["SIMPLE"]
+BLOCK_TO_MONITOR = "ZFCNTRL_01:FIELD:MAGNITUDE"
+IOC_TO_RESTART = ["ZFCNTRL_01", "ZFMAGFLD_01"]
+
+WAIT_BETWEEN_RESTARTS = 120
+WAIT_FOR_POLLING = 10
+
+register_ioc_start(IOC_TO_RUN_IN)
+
+g.set_instrument(None)
+
+while True:
+    block_details = g.cget(BLOCK_TO_MONITOR)
+    if not block_details["connected"] or block_details["alarm"] == "INVALID":
+        for ioc in IOC_TO_RESTART:
+            print("Restarting {}".format(ioc))
+            g.set_pv("CS:PS:{}:RESTART".format(ioc), 1, is_local=True)
+        sleep(WAIT_BETWEEN_RESTARTS)
+    sleep(WAIT_FOR_POLLING)

--- a/general/utilities/restart_ioc_when_pv_in_alarm.py
+++ b/general/utilities/restart_ioc_when_pv_in_alarm.py
@@ -20,7 +20,10 @@ g.set_instrument(None)
 
 while True:
     block_details = g.cget(BLOCK_TO_MONITOR)
-    if block_details["value"] == "No new magnetometer data" or block_details["value"] == "Magnetometer data invalid":
+    block_details_second_check = g.cget(BLOCK_TO_MONITOR)
+    # Check twice to make sure error is consistent
+    if all([pv_update["value"] in ["No new magnetometer data", "Magnetometer data invalid"]
+            for pv_update in [block_details, block_details_second_check]]):
         for ioc in IOC_TO_RESTART:
             print("Restarting {}".format(ioc))
             g.set_pv("CS:PS:{}:RESTART".format(ioc), 1, is_local=True)

--- a/general/utilities/restart_ioc_when_pv_in_alarm.py
+++ b/general/utilities/restart_ioc_when_pv_in_alarm.py
@@ -10,8 +10,8 @@ from server_common.helpers import register_ioc_start
 IOC_TO_RUN_IN = "BGRSCRPT_02"
 #BLOCK_TO_MONITOR = "SIMPLE_VAL"
 #IOC_TO_RESTART = ["SIMPLE"]
-BLOCK_TO_MONITOR = "ZFCNTRL_01:FIELD:MAGNITUDE"
-IOC_TO_RESTART = ["ZFCNTRL_01", "ZFMAGFLD_01"]
+BLOCK_TO_MONITOR = "field_ZF_status"
+IOC_TO_RESTART = ["ZFMAGFLD_01"]
 
 WAIT_BETWEEN_RESTARTS = 120
 WAIT_FOR_POLLING = 10
@@ -22,7 +22,7 @@ g.set_instrument(None)
 
 while True:
     block_details = g.cget(BLOCK_TO_MONITOR)
-    if not block_details["connected"] or block_details["alarm"] == "INVALID":
+    if block_details["value"] == "No new magnetometer data" or block_details["value"] == "Magnetometer data invalid":
         for ioc in IOC_TO_RESTART:
             print("Restarting {}".format(ioc))
             g.set_pv("CS:PS:{}:RESTART".format(ioc), 1, is_local=True)

--- a/general/utilities/restart_ioc_when_pv_in_alarm.py
+++ b/general/utilities/restart_ioc_when_pv_in_alarm.py
@@ -8,8 +8,6 @@ from time import sleep
 from server_common.helpers import register_ioc_start
 
 IOC_TO_RUN_IN = "BGRSCRPT_02"
-#BLOCK_TO_MONITOR = "SIMPLE_VAL"
-#IOC_TO_RESTART = ["SIMPLE"]
 BLOCK_TO_MONITOR = "field_ZF_status"
 IOC_TO_RESTART = ["ZFMAGFLD_01"]
 

--- a/general/utilities/restart_ioc_when_pv_in_alarm.py
+++ b/general/utilities/restart_ioc_when_pv_in_alarm.py
@@ -1,31 +1,31 @@
 import sys
 import os
-
 sys.path.insert(0, os.path.abspath(os.path.join(os.environ["KIT_ROOT"], "ISIS", "inst_servers", "master")))
-
 from genie_python import genie as g
 from time import sleep
 from server_common.helpers import register_ioc_start
+from typing import List
 
 IOC_TO_RUN_IN = "BGRSCRPT_02"
-BLOCK_TO_MONITOR = "field_ZF_status"
-IOC_TO_RESTART = ["ZFMAGFLD_01"]
 
-WAIT_BETWEEN_RESTARTS = 120
-WAIT_FOR_POLLING = 10
 
-register_ioc_start(IOC_TO_RUN_IN)
-
-g.set_instrument(None)
-
-while True:
-    block_details = g.cget(BLOCK_TO_MONITOR)
-    block_details_second_check = g.cget(BLOCK_TO_MONITOR)
-    # Check twice to make sure error is consistent
-    if all([pv_update["value"] in ["No new magnetometer data", "Magnetometer data invalid"]
-            for pv_update in [block_details, block_details_second_check]]):
-        for ioc in IOC_TO_RESTART:
-            print("Restarting {}".format(ioc))
-            g.set_pv("CS:PS:{}:RESTART".format(ioc), 1, is_local=True)
-        sleep(WAIT_BETWEEN_RESTARTS)
-    sleep(WAIT_FOR_POLLING)
+def restart_ioc_when_pv_in_alarm(block_to_monitor: str, iocs_to_restart: List[str], error_states: List[str],
+                                 wait_between_restarts: int = 120, wait_for_polling: int = 10):
+    """
+    Monitor and restart an IOC when a pv goes into a specified alarm state.
+    :param block_to_monitor: Block to monitor PV status.
+    :param iocs_to_restart: List of IOCs to restart if the block goes into an alarm.
+    :param error_states: List of error states that should cause the IOC to restart
+    :param wait_between_restarts: The time (seconds) to wait between restarts
+    :param wait_for_polling: The time (seconds) to wait between polling for the block's value
+    """
+    register_ioc_start(IOC_TO_RUN_IN)
+    g.set_instrument(None)
+    while True:
+        block_details = g.cget(block_to_monitor)
+        if block_details["value"] in error_states:
+            for ioc in iocs_to_restart:
+                print("Restarting {}".format(ioc))
+                g.set_pv("CS:PS:{}:RESTART".format(ioc), 1, is_local=True)
+            sleep(wait_between_restarts)
+        sleep(wait_for_polling)


### PR DESCRIPTION
### Instrument(s)

General, used for DAQmx on EMU

### Story/Acceptance criteria

See ticket

### Description of work

Script for the backgroundscript IOC which restarts an IOC if it becomes disconnected. 

### Issue/Ticket Reference

See ISISComputingGroup/IBEX#5710

### Tests

Manual tests so far, ISISComputingGroup/IBEX/issues/5743 has been created to system test. 

### To test

Check that when the IOC goes into an invalid alarm state the IOC is restarted. 

---

#### Code Review

- [ ] Is the story/acceptance criteria fulfilled?
- [ ] Is the code of an acceptable quality?
- [ ] Are the tests sufficient?
- [ ] Do the changes function as described and is it robust?
- [ ] Are the changes able to work across all intended instruments?

### Final Steps
- [ ] Are there any changes to instrument configurations required?
- [ ] Are there any changes to instrument scripts required, e.g. change on script signature, default argument and have these been communicated?
- [ ] Does the script need to be deployed onto the instrument?
