### PR TITLE
Button scripts

### DIFF
--- a/general/utilities/button_functions.py
+++ b/general/utilities/button_functions.py
@@ -1,0 +1,135 @@
+"""
+Utilities to  run user buttons
+
+See
+"""
+
+import traceback
+from concurrent.futures.thread import ThreadPoolExecutor
+from time import sleep
+
+from genie_python import genie as g
+from genie_python.genie_cachannel_wrapper import CaChannelWrapper, UnableToConnectToPVException
+
+# PV template for the button
+BUTTON_PV_TEMPLATE = "PARS:USER:BUTTON{}"
+
+# Defined buttons
+_buttons = {}
+
+
+class _ButtonMonitor:
+    """
+    Run the general button logic
+    """
+    def __init__(self, button_index, name, function, block_until_pv_exists, retry_delay):
+        """
+        Construct a new button.
+
+        Parameters
+        ----------
+        button_index(int): index of button
+        name(str): name of the action
+        function: function to run when button is pressed. Should have one argument which is a function which sets the
+            status with a string, e.g. func(set_status):  set_state("Starting")
+        block_until_pv_exists: True wait for the block to exist; False throw an exception if the button pv doesn't exist
+        retry_delay: If blocking until the pv exists then retry every this number of seconds
+        """
+        print("Creating button {}".format(name))
+        self._button_index = button_index
+        self._function = function
+
+        self._pv = g.prefix_pv_name(BUTTON_PV_TEMPLATE.format(button_index))
+        self._executor = ThreadPoolExecutor(max_workers=1)
+
+        while True:
+            try:
+                CaChannelWrapper.set_pv_value(self._pv, "")
+                CaChannelWrapper.set_pv_value("{}:SP".format(self._pv), "")
+                CaChannelWrapper.set_pv_value("{}:SP.DESC".format(self._pv), name)
+                self._clear_monitor = CaChannelWrapper.add_monitor("{}:SP".format(self._pv), self._button_function)
+                break
+            except UnableToConnectToPVException:
+                if not block_until_pv_exists:
+                    break
+            sleep(retry_delay)
+
+    def _button_function(self, value, _, __):
+        """
+        If the button is running then run the user function in a thread
+        Parameters
+        ----------
+        value: value of the button set point
+        """
+        if value == "Running":
+            self._executor.submit(self._executed_function)
+
+    def _set_status(self, value):
+        """
+        Set the status pv string to a value
+        Parameters
+        ----------
+        value (str): value to set
+        """
+        print(self._pv)
+        CaChannelWrapper.set_pv_value(self._pv, value)
+
+    def _executed_function(self):
+        """
+        Executes the users function. After the function has run set the set point back to blank.
+        """
+        try:
+            self._function(self._set_status)
+        except Exception:
+            self._set_status("Error")
+            traceback.print_exc()
+            raise
+        finally:
+            CaChannelWrapper.set_pv_value("{}:SP".format(self._pv), "")
+
+    def clean_up(self):
+        """
+        clean_up resources
+        """
+        self._clear_monitor()
+        self._executor.shutdown()
+
+
+def add_button_function(button_index, name, function, block_until_pv_exists=True, retry_delay=5):
+    """
+    Add a function to a given button so it will execute when the button is pressed.
+
+    Parameters
+    ----------
+    button_index: index of the button (0 to NUM_USER_BUTTONS)
+    name: name of the action that function performs
+    function: function to run when button is clicked. Should have one argument which is a function which can be used to
+            set the button status with a string, e.g. def my_func(set_status):  set_state("Starting")
+    block_until_pv_exists: Wait to connect to button until it exists; False throw exception
+    retry_delay: delay between retries if blocking
+
+    Returns
+    -------
+    The button
+    """
+    try:
+        _buttons[button_index].clean_up()
+    except KeyError:
+        # button hasn't been previously defined
+        pass
+    button = _ButtonMonitor(button_index, name, function, block_until_pv_exists, retry_delay)
+    _buttons[button_index] = button
+    return button
+
+
+def run_buttons():
+    """
+    Loop which runs the code for the given buttons, and cleans up after the loop ends.
+    """
+    try:
+        while True:
+            sleep(10)
+    finally:
+        print("clean up")
+        for button in _buttons.values():
+            button.clean_up()

--- a/general/utilities/test/test_button_function.py
+++ b/general/utilities/test/test_button_function.py
@@ -1,0 +1,140 @@
+import unittest
+from time import sleep
+
+from genie_python.channel_access_exceptions import UnableToConnectToPVException
+from mock import Mock, patch
+
+from hamcrest import *
+
+from general.utilities import button_functions
+from general.utilities.button_functions import add_button_function, BUTTON_PV_TEMPLATE
+from CaChannel._ca import AlarmSeverity, AlarmCondition
+
+class OnPVChangeTests(unittest.TestCase):
+    """
+    Tests for the Scan classes
+    """
+
+    def setUp(self) -> None:
+        button_functions._buttons = {}
+
+    @patch("general.utilities.button_functions.g")
+    @patch("general.utilities.button_functions.CaChannelWrapper")
+    def test_GIVEN_function_WHEN_add_button_THEN_monitor_setup(self, ca_channel_wrapper, mock_genie):
+        prefix = "prefix"
+
+        base_pv = "expected_pv"
+        mock_genie.prefix_pv_name.return_value = base_pv
+        mock_function = Mock()
+        button_index = 0
+
+        add_button_function(button_index, "name", mock_function)
+
+        mock_genie.prefix_pv_name.assert_called_with(BUTTON_PV_TEMPLATE.format(button_index))
+        pv = ca_channel_wrapper.add_monitor.call_args[0][0]
+        assert_that(pv, is_("{}:SP".format(base_pv)))
+
+    @patch("general.utilities.button_functions.g")
+    @patch("general.utilities.button_functions.CaChannelWrapper")
+    def test_GIVEN_function_WHEN_pv_set_to_running_THEN_function_is_called(self, ca_channel_wrapper, mock_genie):
+        mock_function = Mock()
+        add_button_function(0, "name", mock_function)
+        function_to_call_on_monitor = ca_channel_wrapper.add_monitor.call_args[0][1]
+
+        function_to_call_on_monitor("Running", AlarmSeverity.No, AlarmCondition.No)
+
+        sleep(0.1)  # wait for function to execute on other thread
+
+        mock_function.assert_called()
+
+    @patch("general.utilities.button_functions.g")
+    @patch("general.utilities.button_functions.CaChannelWrapper")
+    def test_GIVEN_function_WHEN_pv_not_set_to_running_THEN_function_is_not_called(self, ca_channel_wrapper, mock_genie):
+        mock_function = Mock()
+        add_button_function(0, "name", mock_function)
+        function_to_call_on_monitor = ca_channel_wrapper.add_monitor.call_args[0][1]
+
+        function_to_call_on_monitor("", AlarmSeverity.No, AlarmCondition.No)
+
+        sleep(0.1)  # wait for function to execute on other thread
+
+        mock_function.assert_not_called()
+
+    @patch("general.utilities.button_functions.g")
+    @patch("general.utilities.button_functions.CaChannelWrapper")
+    def test_GIVEN_function_WHEN_add_button_THEN_description_is_set_and_function_is_set_as_not_running_and_status_is_blanked(self, ca_channel_wrapper, mock_genie):
+
+        base_pv = "pv"
+        mock_genie.prefix_pv_name.return_value = base_pv
+        mock_function = Mock()
+        button_index = 1
+
+        expected_description = "name"
+        add_button_function(button_index, expected_description, mock_function)
+
+        ca_channel_wrapper.set_pv_value.assert_any_call("{}:SP.DESC".format(base_pv), expected_description)
+        ca_channel_wrapper.set_pv_value.assert_any_call("{}:SP".format(base_pv), "")
+        ca_channel_wrapper.set_pv_value.assert_any_call(base_pv, "")
+
+    @patch("general.utilities.button_functions.g")
+    @patch("general.utilities.button_functions.CaChannelWrapper")
+    def test_GIVEN_add_button_with_block_until_available_WHEN_not_available_and_then_available_THEN_monitor_setup(self, ca_channel_wrapper, mock_genie):
+        prefix = "prefix"
+
+        expected_pv = "expected_pv"
+        mock_genie.prefix_pv_name.return_value = expected_pv
+        ca_channel_wrapper.add_monitor.side_effect = [UnableToConnectToPVException("", ""), None]
+        mock_function = Mock()
+        button_index = 0
+
+        add_button_function(button_index, "name", mock_function, retry_delay=0.1)
+
+        assert_that(ca_channel_wrapper.add_monitor.call_count, is_(2), "add_monitor called twice, after first cal fails")
+
+    @patch("general.utilities.button_functions.g")
+    @patch("general.utilities.button_functions.CaChannelWrapper")
+    def test_GIVEN_function_WHEN_pv_set_to_running_and_function_throws_THEN_button__is_set_back_to_not_running(self, ca_channel_wrapper, mock_genie):
+        base_pv = "pv"
+        mock_genie.prefix_pv_name.return_value = base_pv
+        mock_function = Mock(side_effect=ValueError())
+        add_button_function(0, "name", mock_function)
+        function_to_call_on_monitor = ca_channel_wrapper.add_monitor.call_args[0][1]
+
+        function_to_call_on_monitor("Running", AlarmSeverity.No, AlarmCondition.No)
+
+        sleep(0.1)  # wait for function to execute on other thread
+
+        ca_channel_wrapper.set_pv_value.assert_any_call("{}:SP".format(base_pv), "")
+
+    @patch("general.utilities.button_functions.g")
+    @patch("general.utilities.button_functions.CaChannelWrapper")
+    def test_GIVEN_button_WHEN_finish_THEN_monitor_is_cleared(self, ca_channel_wrapper, mock_genie):
+        clear_func = Mock()
+        ca_channel_wrapper.add_monitor.return_value = clear_func
+        button = add_button_function(0, "name", Mock())
+
+        button.clean_up()
+
+        clear_func.assert_called()
+
+    @patch("general.utilities.button_functions.g")
+    @patch("general.utilities.button_functions.CaChannelWrapper")
+    def test_GIVEN_function_sets_status_pv_WHEN_pv_set_to_running_THEN_status_is_set(self, ca_channel_wrapper, mock_genie):
+        expected_status = "status"
+        base_pv = "pv"
+        mock_genie.prefix_pv_name.return_value = base_pv
+
+        def my_function(set_status):
+            set_status(expected_status)
+        add_button_function(0, "name", my_function)
+        function_to_call_on_monitor = ca_channel_wrapper.add_monitor.call_args[0][1]
+
+        function_to_call_on_monitor("Running", AlarmSeverity.No, AlarmCondition.No)
+
+        sleep(0.1)  # wait for function to execute on other thread
+
+        ca_channel_wrapper.set_pv_value.assert_any_call(base_pv, expected_status)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Instrument(s)

POLREF initially but all instruments

### Story/Acceptance criteria

Allow a user to run a python script from a PV or OPI.

### Description of work

add button function adds functionality to background ioc ability to monitor pvs

### Issue/Ticket Reference

https://github.com/ISISComputingGroup/IBEX/issues/5410

### Tests

See unit tests in pull request

### To test

Setup a background IOC with example script and make sure it can set stuff. On clicking go script should run.
- Make script update the status make sure this updates
- Make script crash, make sure stack trace is printed in IOC log

---

#### Code Review

- [ ] Is the story/acceptance criteria fulfilled?
- [ ] Is the code of an acceptable quality?
- [ ] Are the tests sufficient?
- [ ] Do the changes function as described and is it robust?
- [ ] Are the changes able to work across all intended instruments?

### Final Steps
- [ ] Are there any changes to instrument configurations required?
- [ ] Are there any changes to instrument scripts required, e.g. change on script signature, default argument and have these been communicated?
- [ ] Does the script need to be deployed onto the instrument?
