### PR TITLE
Add kwargs to scan for pixel_range and min/max_pixel. rename detector…

### DIFF
--- a/general/scans/detector.py
+++ b/general/scans/detector.py
@@ -275,7 +275,7 @@ class NormalisedIntensityDetector(DaePeriods):
         >>> scan(...)
 
         or to use specific spectra (these must be called with keywords)
-        >>> scan(... monitor_number=1, detector_number=2)
+        >>> scan(... mon=1, det=2)
 
     """
 
@@ -314,7 +314,7 @@ class NormalisedIntensityDetector(DaePeriods):
         self.monitor = None  # type:SpectraDefinition
         self.detector = None  # type:SpectraDefinition
 
-    def __call__(self, scan, monitor_number=None, detector_number=None, **kwargs):
+    def __call__(self, scan, mon=None, det=None, **kwargs):
         """
         Call detect manger. This is typically done once before a scanning loop
 
@@ -322,9 +322,9 @@ class NormalisedIntensityDetector(DaePeriods):
         ----------
         scan
             scan that is calling this detect routine
-        monitor_number
+        mon
             set the name of the spectra definition to use for the monitor; None use the default
-        detector_number
+        det
             set the name of the spectra definition to use for the detector; None use the default
         kwargs
             arguments to pass to super
@@ -334,9 +334,9 @@ class NormalisedIntensityDetector(DaePeriods):
             self
         """
         super(NormalisedIntensityDetector, self).__call__(scan, **kwargs)
-        monitor_name = monitor_number if monitor_number is not None else self.default_monitor
+        monitor_name = mon if mon is not None else self.default_monitor
         self.monitor = self.spectra_definitions[monitor_name]
-        detector_name = detector_number if detector_number is not None else self.default_detector
+        detector_name = det if det is not None else self.default_detector
         self.detector = self.spectra_definitions[detector_name]
         return self
 
@@ -353,16 +353,25 @@ class NormalisedIntensityDetector(DaePeriods):
         """
         _resume_count_pause(**kwargs)
 
+        det_spectra_range = self._get_multi_detector_pixel_range(**kwargs)
+
         for _ in range(SPECTRA_RETRY_COUNT):  # tries to get a non-None spectrum from the DAE
             monitor_spec_sum = g.integrate_spectrum(self.monitor.spectra_number, g.get_period(),
                                                     self.monitor.t_min, self.monitor.t_max)
-            detector_spec_sum = g.integrate_spectrum(self.detector.spectra_number, g.get_period(),
-                                                     self.detector.t_min, self.detector.t_max)
-
+            detector_spec_sum = 0
+            for spectrum_num in det_spectra_range:
+                det_sum = g.integrate_spectrum(spectrum_num, g.get_period(),
+                                               self.detector.t_min, self.detector.t_max)
+                try:
+                    detector_spec_sum += det_sum
+                except TypeError:
+                    detector_spec_sum = None
+                    break
             if monitor_spec_sum is None or detector_spec_sum is None:
                 print("Spectrum is zero, retrying")
             else:
                 break
+
         else:
             detector_spec_sum = 0
             monitor_spec_sum = 0
@@ -371,3 +380,13 @@ class NormalisedIntensityDetector(DaePeriods):
                                                         detector_spec_sum, monitor_spec_sum))
 
         return acc, Average(detector_spec_sum, monitor_spec_sum)
+
+    def _get_multi_detector_pixel_range(self, **kwargs):
+        if "pixel_range" in kwargs.keys():
+            pixel_range = kwargs.get("pixel_range", 0)
+            return range(max(0, self.detector.spectra_number - pixel_range),
+                         self.detector.spectra_number + pixel_range + 1)
+        else:
+            min_pixel = kwargs.get("min_pixel", self.detector.spectra_number)
+            max_pixel = kwargs.get("max_pixel", self.detector.spectra_number)
+            return range(min_pixel, max_pixel + 1)

--- a/general/scans/detector.py
+++ b/general/scans/detector.py
@@ -353,7 +353,7 @@ class NormalisedIntensityDetector(DaePeriods):
         """
         _resume_count_pause(**kwargs)
 
-        det_spectra_range = self._get_multi_detector_pixel_range(**kwargs)
+        det_spectra_range = self._get_detector_spectra_range(**kwargs)
 
         for _ in range(SPECTRA_RETRY_COUNT):  # tries to get a non-None spectrum from the DAE
             monitor_spec_sum = g.integrate_spectrum(self.monitor.spectra_number, g.get_period(),
@@ -381,7 +381,15 @@ class NormalisedIntensityDetector(DaePeriods):
 
         return acc, Average(detector_spec_sum, monitor_spec_sum)
 
-    def _get_multi_detector_pixel_range(self, **kwargs):
+    def _get_detector_spectra_range(self, **kwargs):
+        """
+        Returns a range of spectrum numbers (=detector pixels) as appropriate for the submitted arguments.
+
+        Args:
+            **kwargs: The keyword arguments
+
+        Returns: The spectra range
+        """
         if "pixel_range" in kwargs.keys():
             pixel_range = kwargs.get("pixel_range", 0)
             return range(max(0, self.detector.spectra_number - pixel_range),

--- a/general/scans/scans.py
+++ b/general/scans/scans.py
@@ -177,7 +177,7 @@ class Scan(object):
                     ((label, unit), position) = next(iter(x.items()))
 
                     # perform measurement
-                    acc, value = detect(acc, **just_times(kwargs))
+                    acc, value = detect(acc, **kwargs)
 
                     if isinstance(value, float):
                         value = Average(value)
@@ -446,7 +446,7 @@ class ContinuousScan(Scan):
                                 self.motion.tolerance:
 
                             position = self.motion()
-                            acc, value = detect(acc, **just_times(kwargs))
+                            acc, value = detect(acc, **kwargs)
                             value = Exact(value)
 
                             xs.append(position)

--- a/general/scans/scans.py
+++ b/general/scans/scans.py
@@ -32,14 +32,6 @@ except ImportError:
     # We must be in a test environment
     from .mocks import g
 
-TIME_KEYS = ["frames", "uamps", "seconds", "minutes", "hours"]
-
-
-def just_times(kwargs):
-    """Filter a dict down to just the waitfor members"""
-    return {x: kwargs[x] for x in kwargs
-            if x in TIME_KEYS}
-
 
 def merge_dicts(x, y):
     """Given two dicts, merge them into a new dict as a shallow copy."""

--- a/instrument/crisp/scans.py
+++ b/instrument/crisp/scans.py
@@ -29,7 +29,7 @@ class CrispDefaultScan(Defaults):
     def __init__(self):
         super(CrispDefaultScan, self).__init__()
 
-    def scan(self, motion, start=None, stop=None, count=None, frames=None, detector_number=None, monitor_number=None,
+    def scan(self, motion, start=None, stop=None, count=None, frames=None, det=None, mon=None,
              **kwargs):
         """
         Scan a motion.
@@ -47,9 +47,9 @@ class CrispDefaultScan(Defaults):
         frames
             number of frames to count for; None either use a different measurement method or define the scan don't
             perform it
-        detector_number
+        det
             the detector spectra number; None use the default
-        monitor_number
+        mon
             the monitor spectra number; None use the default
         kwargs
             various other options consistent with the scan library, common options are:
@@ -62,6 +62,12 @@ class CrispDefaultScan(Defaults):
             detector - Choose how to measure the dependent variable in the scan.  A set of these will have already been
                 defined by your instrument scientist.  If you need something ad hoc, then check the documentation on
                 specific_spectra for more details
+            pixel_range - For summing the counts of multiple pixels. pixel_range is the number of pixels to consider
+                either side of the central detector spectrum
+            min_pixel - For summing the counts of multiple pixels. min_pixel is the spectrum number for the lower bound
+                of the range. Overridden by pixel_range
+            max_pixel - For summing the counts of multiple pixels. max_pixel is the spectrum number for the upper bound
+                of the range. Overridden by pixel_range
 
         Returns
         -------
@@ -72,8 +78,8 @@ class CrispDefaultScan(Defaults):
         Scan theta from -0.5 to 0.5 with 11 steps and counting 100 frames using default detector and monitors
         >>> scan("THETA", -0.5, 0.5, 11, frames=100)
         """
-        return super().scan(motion, start=start, stop=stop, count=count, frames=frames, detector_number=detector_number,
-                            monitor_number=monitor_number, **kwargs)
+        return super().scan(motion, start=start, stop=stop, count=count, frames=frames, det=det,
+                            mon=mon, **kwargs)
 
     @staticmethod
     def log_file(info):

--- a/instrument/demo/scans.py
+++ b/instrument/demo/scans.py
@@ -23,8 +23,8 @@ class DemoDetector(NormalisedIntensityDetector):
     fitting into the window of scanning.
     """
 
-    def __call__(self, scan, monitor_number=None, detector_number=None, **kwargs):
-        super(DemoDetector, self).__call__(scan, monitor_number, detector_number, **kwargs)
+    def __call__(self, scan, mon=None, det=None, **kwargs):
+        super(DemoDetector, self).__call__(scan, mon, det, **kwargs)
 
         points = get_points(None, **kwargs)
         centre = 0.0
@@ -81,7 +81,7 @@ class DemoDefaultScan(Defaults):
         return os.path.join("C:\\", "scripts", "TEST", "{}_{}_{}_{}_{}_{}_{}.dat".format(
             action_title, now.year, now.month, now.day, now.hour, now.minute, now.second))
 
-    def scan(self, motion, start=None, stop=None, count=None, frames=None, detector_number=None, monitor_number=None, **kwargs):
+    def scan(self, motion, start=None, stop=None, count=None, frames=None, det=None, mon=None, **kwargs):
         """
         Scan a motion.
 
@@ -98,9 +98,9 @@ class DemoDefaultScan(Defaults):
         frames
             number of frames to count for; None either use a different measurement method or define the scan don't
             perform it
-        detector_number
+        det
             the detector spectra number; None use the default
-        monitor_number
+        mon
             the monitor spectra number; None use the default
         kwargs
             various other options consistent with the scan library, common options are:
@@ -123,8 +123,8 @@ class DemoDefaultScan(Defaults):
         Scan theta from -0.5 to 0.5 with 11 steps and counting 100 frames using default detector and monitors
         >>> scan("THETA", -0.5, 0.5, 11, frames=100)
         """
-        return super().scan(motion, start=start, stop=stop, count=count, frames=frames, detector_number=detector_number,
-                            monitor_number=monitor_number, **kwargs)
+        return super().scan(motion, start=start, stop=stop, count=count, frames=frames, det=det,
+                            mon=mon, **kwargs)
 
 
 _scan_instance = DemoDefaultScan()

--- a/instrument/inter/scans.py
+++ b/instrument/inter/scans.py
@@ -38,7 +38,7 @@ class InterDefaultScan(Defaults):
     def __init__(self):
         super(InterDefaultScan, self).__init__()
 
-    def scan(self, motion, start=None, stop=None, count=None, frames=None, detector_number=None, monitor_number=None,
+    def scan(self, motion, start=None, stop=None, count=None, frames=None, det=None, mon=None,
              **kwargs):
         """
         Scan a motion.
@@ -56,9 +56,9 @@ class InterDefaultScan(Defaults):
         frames
             number of frames to count for; None either use a different measurement method or define the scan don't
             perform it
-        detector_number
+        det
             the detector spectra number; None use the default
-        monitor_number
+        mon
             the monitor spectra number; None use the default
         kwargs
             various other options consistent with the scan library, common options are:
@@ -71,6 +71,12 @@ class InterDefaultScan(Defaults):
             detector - Choose how to measure the dependent variable in the scan.  A set of these will have already been
                 defined by your instrument scientist.  If you need something ad hoc, then check the documentation on
                 specific_spectra for more details
+            pixel_range - For summing the counts of multiple pixels. pixel_range is the number of pixels to consider
+                either side of the central detector spectrum
+            min_pixel - For summing the counts of multiple pixels. min_pixel is the spectrum number for the lower bound
+                of the range. Overridden by pixel_range
+            max_pixel - For summing the counts of multiple pixels. max_pixel is the spectrum number for the upper bound
+                of the range. Overridden by pixel_range
 
         Returns
         -------
@@ -81,8 +87,8 @@ class InterDefaultScan(Defaults):
         Scan theta from -0.5 to 0.5 with 11 steps and counting 100 frames using default detector and monitors
         >>> scan("THETA", -0.5, 0.5, 11, frames=100)
         """
-        return super().scan(motion, start=start, stop=stop, count=count, frames=frames, detector_number=detector_number,
-                            monitor_number=monitor_number, **kwargs)
+        return super().scan(motion, start=start, stop=stop, count=count, frames=frames, det=det,
+                            mon=mon, **kwargs)
 
     @staticmethod
     def log_file(info):

--- a/instrument/polref/scans.py
+++ b/instrument/polref/scans.py
@@ -38,7 +38,7 @@ class PolrefDefaultScan(Defaults):
     def __init__(self):
         super(PolrefDefaultScan, self).__init__()
 
-    def scan(self, motion, start=None, stop=None, count=None, frames=None, detector_number=None, monitor_number=None,
+    def scan(self, motion, start=None, stop=None, count=None, frames=None, det=None, mon=None,
              **kwargs):
         """
         Scan a motion.
@@ -56,9 +56,9 @@ class PolrefDefaultScan(Defaults):
         frames
             number of frames to count for; None either use a different measurement method or define the scan don't
             perform it
-        detector_number
+        det
             the detector spectra number; None use the default
-        monitor_number
+        mon
             the monitor spectra number; None use the default
         kwargs
             various other options consistent with the scan library, common options are:
@@ -71,6 +71,12 @@ class PolrefDefaultScan(Defaults):
             detector - Choose how to measure the dependent variable in the scan.  A set of these will have already been
                 defined by your instrument scientist.  If you need something ad hoc, then check the documentation on
                 specific_spectra for more details
+            pixel_range - For summing the counts of multiple pixels. pixel_range is the number of pixels to consider
+                either side of the central detector spectrum
+            min_pixel - For summing the counts of multiple pixels. min_pixel is the spectrum number for the lower bound
+                of the range. Overridden by pixel_range
+            max_pixel - For summing the counts of multiple pixels. max_pixel is the spectrum number for the upper bound
+                of the range. Overridden by pixel_range
 
         Returns
         -------
@@ -81,8 +87,8 @@ class PolrefDefaultScan(Defaults):
         Scan theta from -0.5 to 0.5 with 11 steps and counting 100 frames using default detector and monitors
         >>> scan("THETA", -0.5, 0.5, 11, frames=100)
         """
-        return super().scan(motion, start=start, stop=stop, count=count, frames=frames, detector_number=detector_number,
-                            monitor_number=monitor_number, **kwargs)
+        return super().scan(motion, start=start, stop=stop, count=count, frames=frames, det=det,
+                            mon=mon, **kwargs)
 
     @staticmethod
     def log_file(info):

--- a/instrument/surf/scans.py
+++ b/instrument/surf/scans.py
@@ -38,7 +38,7 @@ class SurfDefaultScan(Defaults):
     def __init__(self):
         super(SurfDefaultScan, self).__init__()
 
-    def scan(self, motion, start=None, stop=None, count=None, frames=None, detector_number=None, monitor_number=None,
+    def scan(self, motion, start=None, stop=None, count=None, frames=None, det=None, mon=None,
              **kwargs):
         """
         Scan a motion.
@@ -56,9 +56,9 @@ class SurfDefaultScan(Defaults):
         frames
             number of frames to count for; None either use a different measurement method or define the scan don't
             perform it
-        detector_number
+        det
             the detector spectra number; None use the default
-        monitor_number
+        mon
             the monitor spectra number; None use the default
         kwargs
             various other options consistent with the scan library, common options are:
@@ -71,6 +71,12 @@ class SurfDefaultScan(Defaults):
             detector - Choose how to measure the dependent variable in the scan.  A set of these will have already been
                 defined by your instrument scientist.  If you need something ad hoc, then check the documentation on
                 specific_spectra for more details
+            pixel_range - For summing the counts of multiple pixels. pixel_range is the number of pixels to consider
+                either side of the central detector spectrum
+            min_pixel - For summing the counts of multiple pixels. min_pixel is the spectrum number for the lower bound
+                of the range. Overridden by pixel_range
+            max_pixel - For summing the counts of multiple pixels. max_pixel is the spectrum number for the upper bound
+                of the range. Overridden by pixel_range
 
         Returns
         -------
@@ -81,8 +87,8 @@ class SurfDefaultScan(Defaults):
         Scan theta from -0.5 to 0.5 with 11 steps and counting 100 frames using default detector and monitors
         >>> scan("THETA", -0.5, 0.5, 11, frames=100)
         """
-        return super().scan(motion, start=start, stop=stop, count=count, frames=frames, detector_number=detector_number,
-                            monitor_number=monitor_number, **kwargs)
+        return super().scan(motion, start=start, stop=stop, count=count, frames=frames, det=det,
+                            mon=mon, **kwargs)
 
     @staticmethod
     def log_file(info):


### PR DESCRIPTION
…/monitor_number args to det/mon

### Instrument(s)

Reflectometers

### Story/Acceptance criteria

- Users can specify a range of pixels for which to sum the counts in each scan step.

### Description of work

Added kwargs to the scan command to specify a detector pixel range. Set either:
- `pixel_range`: a number specifying the number of pixels either side of the chosen detector spectrum. 
     - e.g. `scan(..., det=280, pixel_range=3)` will give you summed counts for spectra 277 to 283
- `min_pixel` / `max_pixel`: two number specifying the number of the minimum / maximum spectrum number in the range 
     - e.g. `scan(..., min_pixel=277, max_pixel=283)` will give you summed counts for spectra 277 to 283

Also renamed `monitor_number` and `detector_number` args to `det` / `mon` for typing convenience.

### Issue/Ticket Reference

https://github.com/ISISComputingGroup/IBEX/issues/5472

### Tests

- See unit tests
- Also confirmed the correct spectra are set on a live console session run from the IBEX client by printing spectra numbers when looping over the range (but without neutrons)

### To test

- Check out POLREF branch in config area
- Run `scan` with `pixel_range` or `min/max_pixel` args set
- Check counts for the correct spectra are being added to the sum in `detector_measurement` (e.g. attach a debugger)

---

#### Code Review

- [ ] Is the story/acceptance criteria fulfilled?
- [ ] Is the code of an acceptable quality?
- [ ] Are the tests sufficient?
- [ ] Do the changes function as described and is it robust?
- [ ] Are the changes able to work across all intended instruments?

### Final Steps
- [ ] Are there any changes to instrument configurations required?
- [ ] Are there any changes to instrument scripts required, e.g. change on script signature, default argument and have these been communicated?
- [ ] Does the script need to be deployed onto the instrument?
