### PR TITLE
Ticket5785 interrupt

### DIFF
--- a/general/scans/defaults.py
+++ b/general/scans/defaults.py
@@ -163,6 +163,7 @@ class Defaults(object):
           A scan object that will run through the requested points.
 
         """
+        num_periods_cache = g.get_number_periods()
         try:
             if start is not None:
                 kwargs["start"] = start
@@ -200,6 +201,7 @@ class Defaults(object):
                     g.end()
                 else:
                     g.abort()
+            g.change_number_soft_periods(num_periods_cache)
             raise KeyboardInterrupt
 
     def ascan(self, motion, start, end, intervals, time):


### PR DESCRIPTION
### Instrument(s)

All

### Story/Acceptance criteria

Keyboard interrupts were not propagating to the top level of the python interpreter. i.e. `ctrl+c`-ing a scan running inside a loop would interrupt that specific call to `scan` but would then run the next iteration of the loop.

### Description of work

Keyboard interrupts are no longer ignored inside the scan command. Added an interrupt handler to ensure runs are stopped/aborted on interrupting a scan and number of periods are reverted to their value before the scan.

### Issue/Ticket Reference

https://github.com/ISISComputingGroup/IBEX/issues/5785

### Tests

Checked that no further code is executed in a loop when keyboard-interrupting a scan - see below.

Added automated system test: https://github.com/ISISComputingGroup/System_Tests_UI_E4/pull/73

### To test

1. check out master branch of scans library
2. in the ibex client, go to the scripting console
3. run the following code: 
  ```
  from instrument.demo import scan`
  for i in range(10):
      print("loop iteration {}".format(i))
      scan(b.SOME_BLOCK, 0, 1, 3, 500)
  ```
4. wait until in the middle of the scan (e.g. when the DAE starts counting), then press ctrl+c in console
5. confirm the next loop iteration is executed
6. check out ticket branch, then repeat the above
7. confirm the next loop iteration is not executed

---

#### Code Review

- [ ] Is the story/acceptance criteria fulfilled?
- [ ] Is the code of an acceptable quality?
- [ ] Are the tests sufficient?
- [ ] Do the changes function as described and is it robust?
- [ ] Are the changes able to work across all intended instruments?

### Final Steps
- [ ] Are there any changes to instrument configurations required?
- [ ] Are there any changes to instrument scripts required, e.g. change on script signature, default argument and have these been communicated?
- [ ] Does the script need to be deployed onto the instrument?
