### PR TITLE
Fix POLREF spectra definitions

### DIFF
--- a/instrument/polref/scans.py
+++ b/instrument/polref/scans.py
@@ -29,11 +29,14 @@ class PolrefDefaultScan(Defaults):
     """
 
     # spectra definition based on gcl script.
-    _spectra_definitions = [create_spectra_definition(1, 1050.0, 15500.0),
-                            create_spectra_definition(2, 1050.0, 15500.0),
-                            create_spectra_definition(3, 1450.0, 16500.0)]
+    _single_det_spectra = [create_spectra_definition(1, 100.0, 50000.0),  # Chopper pit
+                           create_spectra_definition(2, 100.0, 60000.0),  # Front of Blockhouse
+                           create_spectra_definition(3, 3000.0, 70000.0),  # Before Sample
+                           create_spectra_definition(4, 3000.0, 70000.0)]  # Point detector
+    _multi_det_spectra = [create_spectra_definition(i, 3800.0, 90000.0) for i in range(5, 646)]  # linear detector
+
     detector = NormalisedIntensityDetector(default_monitor=2, default_detector=3,
-                                           spectra_definitions=_spectra_definitions)
+                                           spectra_definitions=_single_det_spectra + _multi_det_spectra)
 
     def __init__(self):
         super(PolrefDefaultScan, self).__init__()

--- a/instrument/polref/scans.py
+++ b/instrument/polref/scans.py
@@ -29,13 +29,13 @@ class PolrefDefaultScan(Defaults):
     """
 
     # spectra definition based on gcl script.
-    _single_det_spectra = [create_spectra_definition(1, 100.0, 50000.0),  # Chopper pit
-                           create_spectra_definition(2, 100.0, 60000.0),  # Front of Blockhouse
+    _single_det_spectra = [create_spectra_definition(1, 100.0, 50000.0),   # Chopper pit
+                           create_spectra_definition(2, 100.0, 60000.0),   # Front of Blockhouse
                            create_spectra_definition(3, 3000.0, 70000.0),  # Before Sample
                            create_spectra_definition(4, 3000.0, 70000.0)]  # Point detector
     _multi_det_spectra = [create_spectra_definition(i, 3800.0, 90000.0) for i in range(5, 646)]  # linear detector
 
-    detector = NormalisedIntensityDetector(default_monitor=2, default_detector=3,
+    detector = NormalisedIntensityDetector(default_monitor=2, default_detector=280,
                                            spectra_definitions=_single_det_spectra + _multi_det_spectra)
 
     def __init__(self):
@@ -108,7 +108,7 @@ class PolrefDefaultScan(Defaults):
         from datetime import datetime
         now = datetime.now()
         action_title = info.get("action_title", "unknown")
-        return os.path.join("U:\\", "scripts", "TEST", "{}_{}_{}_{}_{}_{}_{}.dat".format(
+        return os.path.join("U:\\", "TEST", "{}_{}_{}_{}_{}_{}_{}.dat".format(
             action_title, now.year, now.month, now.day, now.hour, now.minute, now.second))
 
 


### PR DESCRIPTION
### Instrument(s)

POLREF

### Story/Acceptance criteria

POLREF still had the spectra definitions from CRISP in their scans setup file. These changes define the actual spectra ranges for all detectors (as taken from Mantid etc.)

### Description of work

Just updating some hardcoded values.