### PR TITLE
Make data in scans write to script dir by default

### DIFF
--- a/general/scans/plot_functions.py
+++ b/general/scans/plot_functions.py
@@ -88,7 +88,7 @@ class PlotFunctions:
                                         marker=marker, markersize=self.data_marker_size, linestyle="None")
             else:
                 self._axis.errorbar(xs, ys.values(), yerr=ys.err(), color=self.color_cycle[0],
-                                    marker=self.data_markers[0], markersize=self.data_marker_size)
+                                    marker=self.data_markers[0], markersize=self.data_marker_size, linestyle="None")
 
     def _plot_range(self, points):
         """

--- a/general/scans/scans.py
+++ b/general/scans/scans.py
@@ -824,33 +824,26 @@ class ReplayScan(Scan):
 
     def plot(self, detector=None, save=None,
              action=None, **kwargs):
-        """Overload the scan method for the replay scan.  Since we aren't
-actually detecting anything, we can run the code much simpler instead
-of trying to fake a detector."""
+        """
+        Overload the scan method for the replay scan.  Since we aren't
+        actually detecting anything, we can run the code much simpler instead
+        of trying to fake a detector."""
+
         action_remainder = None
         xs = self.xs
         ys = ListOfMonoids(self.ys)
 
+        plot_functions = self.defaults.plot_functions
         fig, axis = self.defaults.get_fig()
+        plot_functions.set_figure_and_axis(fig, axis)
 
-        axis.clear()
-        if isinstance(self.min(), tuple):
-            rng = [1.05 * self.min()[0] - 0.05 * self.max()[0],
-                   1.05 * self.max()[0] - 0.05 * self.min()[0]]
-        else:
-            rng = [1.05 * self.min() - 0.05 * self.max(),
-                   1.05 * self.max() - 0.05 * self.min()]
-        axis.set_xlabel(self.axis)
-        axis.set_ylabel(self.result)
-        axis.set_xlim(rng[0], rng[1])
-        rng = _plot_range(ys)
-        axis.set_ylim(rng[0], rng[1])
-        ys.plot(axis, xs)
+        plot_functions.setup_plot(self.min(), self.max(), x_label=self.axis, y_label=self.result)
+        plot_functions.plot_data_with_errors(xs, ys)
+
         if action:
-            action_remainder = action(xs, ys, axis, None)
-        if save:
-            fig.savefig(save)
+            action_remainder = action(xs, ys, plot_functions, None)
 
-        plt.draw()
+        plot_functions.draw()
+        plot_functions.save(save)
 
         return action_remainder

--- a/instrument/crisp/scans.py
+++ b/instrument/crisp/scans.py
@@ -81,22 +81,6 @@ class CrispDefaultScan(Defaults):
         return super().scan(motion, start=start, stop=stop, count=count, frames=frames, det=det,
                             mon=mon, **kwargs)
 
-    @staticmethod
-    def log_file(info):
-        """
-        Returns the name of a unique log file where the scan data can be saved.
-        Parameters:
-            info: dictionary containing useful keys to help form paths. It may contain no keys at all.
-                    possible keys are action_title - the name of the action requested
-        Returns:
-            Name for the log file
-        """
-        from datetime import datetime
-        now = datetime.now()
-        action_title = info.get("action_title", "unknown")
-        return os.path.join("U:\\", "scripts", "TEST", "{}_{}_{}_{}_{}_{}_{}.dat".format(
-            action_title, now.year, now.month, now.day, now.hour, now.minute, now.second))
-
 
 _scan_instance = CrispDefaultScan()
 scan = _scan_instance.scan

--- a/instrument/demo/scans.py
+++ b/instrument/demo/scans.py
@@ -63,24 +63,6 @@ class DemoDefaultScan(Defaults):
     def __init__(self):
         super(DemoDefaultScan, self).__init__()
 
-    @staticmethod
-    def log_file(info):
-        """
-        Parameters
-        ----------
-            info
-              dictionary containing useful keys to help form paths. It may contain no keys at all.
-                    possible keys are action_title - the name of the action requested
-        Returns
-        -------
-            Name for the log file
-        """
-        from datetime import datetime
-        now = datetime.now()
-        action_title = info.get("action_title", "unknown")
-        return os.path.join("C:\\", "scripts", "TEST", "{}_{}_{}_{}_{}_{}_{}.dat".format(
-            action_title, now.year, now.month, now.day, now.hour, now.minute, now.second))
-
     def scan(self, motion, start=None, stop=None, count=None, frames=None, det=None, mon=None, **kwargs):
         """
         Scan a motion.

--- a/instrument/inter/scans.py
+++ b/instrument/inter/scans.py
@@ -90,23 +90,6 @@ class InterDefaultScan(Defaults):
         return super().scan(motion, start=start, stop=stop, count=count, frames=frames, det=det,
                             mon=mon, **kwargs)
 
-    @staticmethod
-    def log_file(info):
-        """
-        Parameters
-        ----------
-            info
-              dictionary containing useful keys to help form paths. It may contain no keys at all.
-                    possible keys are action_title - the name of the action requested
-        Returns
-        -------
-            Name for the log file
-        """
-        from datetime import datetime
-        now = datetime.now()
-        action_title = info.get("action_title", "unknown")
-        return os.path.join("U:\\", "scripts", "TEST", "{}_{}_{}_{}_{}_{}_{}.dat".format(
-            action_title, now.year, now.month, now.day, now.hour, now.minute, now.second))
 
 
 _scan_instance = InterDefaultScan()

--- a/instrument/polref/scans.py
+++ b/instrument/polref/scans.py
@@ -93,23 +93,6 @@ class PolrefDefaultScan(Defaults):
         return super().scan(motion, start=start, stop=stop, count=count, frames=frames, det=det,
                             mon=mon, **kwargs)
 
-    @staticmethod
-    def log_file(info):
-        """
-        Parameters
-        ----------
-            info
-              dictionary containing useful keys to help form paths. It may contain no keys at all.
-                    possible keys are action_title - the name of the action requested
-        Returns
-        -------
-            Name for the log file
-        """
-        from datetime import datetime
-        now = datetime.now()
-        action_title = info.get("action_title", "unknown")
-        return os.path.join("U:\\", "TEST", "{}_{}_{}_{}_{}_{}_{}.dat".format(
-            action_title, now.year, now.month, now.day, now.hour, now.minute, now.second))
 
 
 _scan_instance = PolrefDefaultScan()

--- a/instrument/surf/scans.py
+++ b/instrument/surf/scans.py
@@ -90,23 +90,6 @@ class SurfDefaultScan(Defaults):
         return super().scan(motion, start=start, stop=stop, count=count, frames=frames, det=det,
                             mon=mon, **kwargs)
 
-    @staticmethod
-    def log_file(info):
-        """
-        Parameters
-        ----------
-            info
-              dictionary containing useful keys to help form paths. It may contain no keys at all.
-                    possible keys are action_title - the name of the action requested
-        Returns
-        -------
-            Name for the log file
-        """
-        from datetime import datetime
-        now = datetime.now()
-        action_title = info.get("action_title", "unknown")
-        return os.path.join("U:\\", "scripts", "TEST", "{}_{}_{}_{}_{}_{}_{}.dat".format(
-            action_title, now.year, now.month, now.day, now.hour, now.minute, now.second))
 
 
 _scan_instance = SurfDefaultScan()


### PR DESCRIPTION
Make last scan read from script dir

### Instrument(s)

All, but will only effect directly POLREF, SURF, CRISP and INTER

### Story/Acceptance criteria

Scans should save data in the genie_python scrip folder and last_scan should read data from log_file directory.

### Description of work

Implement the above

### Issue/Ticket Reference

https://github.com/ISISComputingGroup/IBEX/issues/5794

### Tests

Unit

### To test

Run scan and make sure data is saved to genie_python script dir for the demo instrument.
Make sure last scan reads the data from that directory and that you can do last_scan(fit=Gaussian)


---

#### Code Review

- [ ] Is the story/acceptance criteria fulfilled?
- [ ] Is the code of an acceptable quality?
- [ ] Are the tests sufficient?
- [ ] Do the changes function as described and is it robust?
- [ ] Are the changes able to work across all intended instruments?

### Final Steps
- [ ] Are there any changes to instrument configurations required?
- [ ] Are there any changes to instrument scripts required, e.g. change on script signature, default argument and have these been communicated?
- [ ] Does the script need to be deployed onto the instrument?
