### PR TITLE
Create fig first in scan

### DIFF
--- a/general/scans/defaults.py
+++ b/general/scans/defaults.py
@@ -73,9 +73,9 @@ class Defaults(object):
         return os.path.join(base_dir, "{}_{}_{}_{}_{}_{}_{}.dat".format(
             action_title, now.year, now.month, now.day, now.hour, now.minute, now.second))
 
-    def get_fig(self):
+    def create_fig(self):
         """
-        Get a figure for the next scan.  The default method is to
+        Create a figure for the next scan.  The default method is to
         create a new figure for each scan, but this can be overridden
         to re-use the same figure, if the instrument scientist
         chooses.
@@ -83,11 +83,14 @@ class Defaults(object):
         if self.SINGLE_FIGURE:
             if not self._fig or not self._axis:
                 self._fig, self._axis = plt.subplots()
-                plt.show()
-            return (self._fig, self._axis)
-        fig, axis = plt.subplots()
-        plt.show()
-        return (fig, axis)
+        else:
+            self._fig, self._axis = plt.subplots()
+
+    def get_fig(self):
+        """
+        Get the figure for the next scan.
+        """
+        return (self._fig, self._axis)
 
     def scan(self, motion, start=None, stop=None, step=None, frames=None, save=False, **kwargs):
         """scan establishes the setup for performing a measurement scan.
@@ -174,6 +177,8 @@ class Defaults(object):
           A scan object that will run through the requested points.
 
         """
+        self.create_fig()
+        plt.show()
         num_periods_cache = g.get_number_periods()
         try:
             if start is not None:


### PR DESCRIPTION
### Instrument(s)

All

### Story/Acceptance criteria

There was a bug in the IBEX gui where when the perspective was switched directly after starting a scan, the matplotlib plot would pop up in the new perspective. We don't want this to happen.

### Description of work

Matplotlib plot is now created at the start of the scan instead of in the middle, which makes the window of opportunity for this bug to appear much shorter. If you are dedicated enough you can still reproduce the bug (i.e. switch perspective almost instantly as you run the scan) however it's very unlikely to happen by accident so I think this should be an acceptable solution.

### Issue/Ticket Reference

https://github.com/ISISComputingGroup/IBEX/issues/5848

### Tests

/

### To test

1. In your instrument startup script (`init_<inst>.py`) add the following:
```
import sys
import os
sys.path.insert(0, os.path.abspath(os.path.join(r"C:\\", "Instrument", "scripts")))

from genie_python import genie as g, BLOCK_NAMES as b
from instrument.demo import *

def quick_scan():
    scan(b.<some_block>, 0, 1, 3, 50)
```
2. Go to the scripting perspective in the IBEX client
3. run `quick_scan()` and switch perspective. Confirm the matplotlib window appears only in the original perspective.
4. The same is true for the reflectometry perspective.
5. The same is true for  `scan` imported from any other instrument.

---

#### Code Review

- [ ] Is the story/acceptance criteria fulfilled?
- [ ] Is the code of an acceptable quality?
- [ ] Are the tests sufficient?
- [ ] Do the changes function as described and is it robust?
- [ ] Are the changes able to work across all intended instruments?

### Final Steps
- [ ] Are there any changes to instrument configurations required?
- [ ] Are there any changes to instrument scripts required, e.g. change on script signature, default argument and have these been communicated?
- [ ] Does the script need to be deployed onto the instrument?
