### PR TITLE
Add auto height function

### DIFF
--- a/general/utilities/io.py
+++ b/general/utilities/io.py
@@ -5,7 +5,6 @@ from genie_python import genie as g
 
 
 def alert_on_error(error_msg: str, prompt_user: bool):
-    print(error_msg)
     """
     Sends a given error message as an alert an optionally interrupts execution to prompt the user whether the script
     should continue being executed.
@@ -14,6 +13,7 @@ def alert_on_error(error_msg: str, prompt_user: bool):
         error_msg: The message for the error to alert users to.
         prompt_user: If false, continue script. If True, prompt user to either stop or continue script.
     """
+    print(error_msg)
     g.alerts.send(error_msg)
     if prompt_user:
         while True:

--- a/general/utilities/io.py
+++ b/general/utilities/io.py
@@ -1,0 +1,26 @@
+"""
+Input / Output utilities
+"""
+from genie_python import genie as g
+
+
+def alert_on_error(error_msg: str, prompt_user: bool):
+    print(error_msg)
+    """
+    Sends a given error message as an alert an optionally interrupts execution to prompt the user whether the script
+    should continue being executed.
+
+    Args:
+        error_msg: The message for the error to alert users to.
+        prompt_user: If false, continue script. If True, prompt user to either stop or continue script.
+    """
+    g.alerts.send(error_msg)
+    if prompt_user:
+        while True:
+            user_response = input("Continue execution? [Y/N]\n").upper()
+            if user_response == "Y":
+                break
+            elif user_response == "N":
+                raise KeyboardInterrupt
+            else:
+                print("Please type in 'Y' or 'N' as a response.")

--- a/technique/reflectometry/__init__.py
+++ b/technique/reflectometry/__init__.py
@@ -1,4 +1,4 @@
 
-from .base import run_angle, transmission, slit_check
+from .base import run_angle, transmission, slit_check, auto_height
 from .contrast_change import contrast_change
 from .sample import SampleGenerator, Sample

--- a/technique/reflectometry/base.py
+++ b/technique/reflectometry/base.py
@@ -40,7 +40,7 @@ def run_angle(sample, angle, count_uamps=None, count_seconds=None, count_frames=
         fine_height_block: The block for the sample fine height
         auto_height_target: The target value for laser offset if using auto height
         continue_on_error: If True, continue script on error; If False, interrupt and prompt the user on error
-        dry_run: If True just print what will happen; If False, run the experiment
+        dry_run: If True just print what would happen; If False, run the experiment
 
     Examples:
         The simplest scan is:
@@ -128,7 +128,7 @@ def transmission(sample, title, s1vg, s2vg, s3vg=None, s4vg=None,
         height_offset: Height offset from normal to set the sample to (offset is in negative direction)
         smangle: super mirror angle, place in the beam, if set to 0 remove from the beam; None don't move super mirror
         mode: mode to run in; None don't change mode
-        dry_run: If True just print what will happen; If False, run the transmission
+        dry_run: If True just print what would happen; If False, run the transmission
     Examples:
         The simplest transmission is:
 

--- a/technique/reflectometry/base.py
+++ b/technique/reflectometry/base.py
@@ -273,14 +273,14 @@ def auto_height(laser_block: str, fine_height_block: str, target: float = 0.0, m
 
         Moves HEIGHT2 by (target - KEYENCE), but only if that value is < 3.0
     """
-    current_laser_offset = g.cget(laser_block)
+    current_laser_offset = g.cget(laser_block)["value"]
 
     difference = target - current_laser_offset
-    current_height = g.cget(fine_height_block)
+    current_height = g.cget(fine_height_block)["value"]
 
     target_height = current_height + difference
 
-    print("Target for fine height axis: {}".format(target_height))
+    print("Target for fine height axis: {} (current {})".format(target_height, current_height))
 
     if max_move_distance is None:
         g.cset(fine_height_block, target_height)

--- a/technique/reflectometry/base.py
+++ b/technique/reflectometry/base.py
@@ -273,22 +273,27 @@ def auto_height(laser_block: str, fine_height_block: str, target: float = 0.0, m
 
         Moves HEIGHT2 by (target - KEYENCE), but only if that value is < 3.0
     """
-    current_laser_offset = g.cget(laser_block)["value"]
+    try:
+        current_laser_offset = g.cget(laser_block)["value"]
 
-    difference = target - current_laser_offset
-    current_height = g.cget(fine_height_block)["value"]
+        difference = target - current_laser_offset
+        current_height = g.cget(fine_height_block)["value"]
 
-    target_height = current_height + difference
+        target_height = current_height + difference
 
-    print("Target for fine height axis: {} (current {})".format(target_height, current_height))
+        print("Target for fine height axis: {} (current {})".format(target_height, current_height))
 
-    if max_move_distance is None:
-        g.cset(fine_height_block, target_height)
-    else:
-        if abs(target_height - current_height) < 3.0:
+        if max_move_distance is None:
             g.cset(fine_height_block, target_height)
         else:
-            print("Difference between current and target position too large - no move")
+            if abs(target_height - current_height) < 3.0:
+                g.cset(fine_height_block, target_height)
+            else:
+                print("Difference between current and target position too large - no move")
+
+    except TypeError:
+        print("Error setting auto height - Invalid block value")
+
 
 
 class _Movement(object):

--- a/technique/reflectometry/base.py
+++ b/technique/reflectometry/base.py
@@ -255,6 +255,42 @@ def slit_check(theta, footprint, resolution):
     print("s2vg={}".format(s2))
 
 
+def auto_height(laser_block: str, fine_height_block: str, target: float = 0.0, max_move_distance: float = None):
+    """
+    Moves the sample fine height axis so that it is centred on the beam, based on the readout of a laser height gun.
+
+    Args:
+        laser_block: The block for the laser offset from centre
+        fine_height_block: The block for the sample fine height
+        target: The target laser offset
+        max_move_distance: Do not move if difference between current and target height is above this threshold.
+            None for no limit
+        >>> auto_height(b.KEYENCE, b.HEIGHT2)
+
+        Moves HEIGHT2 by (KEYENCE * (-1))
+
+        >>> auto_height(b.KEYENCE, b.HEIGHT2, target=0.5, limit=3.0)
+
+        Moves HEIGHT2 by (target - KEYENCE), but only if that value is < 3.0
+    """
+    current_laser_offset = g.cget(laser_block)
+
+    difference = target - current_laser_offset
+    current_height = g.cget(fine_height_block)
+
+    target_height = current_height + difference
+
+    print("Target for fine height axis: {}".format(target_height))
+
+    if max_move_distance is None:
+        g.cset(fine_height_block, target_height)
+    else:
+        if abs(target_height - current_height) < 3.0:
+            g.cset(fine_height_block, target_height)
+        else:
+            print("Difference between current and target position too large - no move")
+
+
 class _Movement(object):
     """
     Encapsulate instrument changes

--- a/technique/reflectometry/base.py
+++ b/technique/reflectometry/base.py
@@ -11,7 +11,7 @@ from math import tan, radians, sin
 from six.moves import input
 from genie_python import genie as g
 
-from general.utilities.io import alert_on_error
+import general.utilities.io
 from .sample import Sample
 from .instrument_constants import get_instrument_constants
 
@@ -92,7 +92,7 @@ def run_angle(sample, angle, count_uamps=None, count_seconds=None, count_frames=
         movement.set_height_offset(sample.height)
     else:
         auto_height(laser_offset_block, fine_height_block, target=auto_height_target,
-                    continue_if_NaN=continue_on_error, dry_run=dry_run)
+                    continue_if_nan=continue_on_error, dry_run=dry_run)
 
     movement.set_slit_gaps(angle, constants, s1vg, s2vg, s3vg, s4vg, sample)
     movement.wait_for_move()
@@ -262,7 +262,7 @@ def slit_check(theta, footprint, resolution):
     print("s2vg={}".format(s2))
 
 
-def auto_height(laser_offset_block: str, fine_height_block: str, target: float = 0.0, continue_if_NaN: bool=False,
+def auto_height(laser_offset_block: str, fine_height_block: str, target: float = 0.0, continue_if_nan: bool = False,
                 dry_run: bool = False):
     """
     Moves the sample fine height axis so that it is centred on the beam, based on the readout of a laser height gun.
@@ -271,7 +271,7 @@ def auto_height(laser_offset_block: str, fine_height_block: str, target: float =
         laser_offset_block: The name of the block for the laser offset from centre
         fine_height_block: The name of the block for the sample fine height axis
         target: The target laser offset
-        continue_if_NaN: Defines what to do in case of invalid values. If True, ignore errors and continue execution.
+        continue_if_nan: Defines what to do in case of invalid values. If True, ignore errors and continue execution.
             If False, break and wait for user input. (default: False)
         dry_run: If True just print what is going to happen; If False, set the auto height
         
@@ -279,7 +279,7 @@ def auto_height(laser_offset_block: str, fine_height_block: str, target: float =
 
         Moves HEIGHT2 by (KEYENCE * (-1))
 
-        >>> auto_height(b.KEYENCE, b.HEIGHT2, target=0.5, continue_if_NaN=True)
+        >>> auto_height(b.KEYENCE, b.HEIGHT2, target=0.5, continue_if_nan=True)
 
         Moves HEIGHT2 by (target - b.KEYENCE) and does not interrupt script execution if an invalid value is read.
     """
@@ -290,8 +290,8 @@ def auto_height(laser_offset_block: str, fine_height_block: str, target: float =
             _auto_height_check_alarms(fine_height_block)
             g.waitfor_move()
     except TypeError as e:
-        prompt_user = not (continue_if_NaN or dry_run)
-        alert_on_error("ERROR: cannot set auto height (invalid block value): {}".format(e), prompt_user)
+        prompt_user = not (continue_if_nan or dry_run)
+        general.utilities.io.alert_on_error("ERROR: cannot set auto height (invalid block value): {}".format(e), prompt_user)
 
 
 def _auto_height_check_alarms(fine_height_block):
@@ -303,7 +303,8 @@ def _auto_height_check_alarms(fine_height_block):
     """
     alarm_lists = g.check_alarms(fine_height_block)
     if any(fine_height_block in alarm_list for alarm_list in alarm_lists):
-        alert_on_error("ERROR: cannot set auto height (target outside of range for fine height axis?)", True)
+        general.utilities.io.alert_on_error(
+            "ERROR: cannot set auto height (target outside of range for fine height axis?)", True)
 
 
 def _calculate_target_auto_height(laser_offset_block, fine_height_block, target):

--- a/technique/reflectometry/base.py
+++ b/technique/reflectometry/base.py
@@ -297,7 +297,15 @@ def auto_height(laser_block: str, fine_height_block: str, target: float = 0.0, c
         print(error_msg)
         g.alerts.send(error_msg)
         if not continue_if_NaN:
-            input("Press enter to continue...")
+            while True:
+                response = input("Continue execution? [Y/N]\n").upper()
+                if response == "Y":
+                    break
+                elif response == "N":
+                    raise KeyboardInterrupt
+                else:
+                    print("Please type in 'Y' or 'N' as a response.")
+
 
 
 class _Movement(object):

--- a/technique/reflectometry/test/test_base.py
+++ b/technique/reflectometry/test/test_base.py
@@ -1,15 +1,19 @@
 import unittest
 from collections import OrderedDict
-from mock import Mock
+from contextlib import contextmanager
 
-from ..base import reset_hgaps_and_sample_height
+import mock
+from mock import Mock, patch
+from parameterized import parameterized
+from genie_python import genie as g
+
+from ..base import reset_hgaps_and_sample_height, auto_height
 
 
 class ReflBaseTest(unittest.TestCase):
     """
     Tests
     """
-
     def test_GIVEN_reset_hgaps_WHEN_noop_THEN_hgaps_reset(self):
         movement = Mock()
 
@@ -30,3 +34,129 @@ class ReflBaseTest(unittest.TestCase):
 
         noop_function()
         movement.set_h_gaps.assert_called_with(**expected_ordered_dict)
+
+
+@contextmanager
+def genie_python_sim(block_inits=None, blocks_in_alarm=None):
+    """
+    Context which creates a fake block server by mocking out parts of genie
+
+    Parameters
+    ----------
+    block_and_value: blocks and their initial values
+
+    Returns
+    -------
+    nothing
+    """
+    blocks = {}
+    if block_inits is None:
+        block_inits = {}
+    if blocks_in_alarm is None:
+        blocks_in_alarm = []
+    with patch("genie_python.genie.cget") as cget, \
+            patch("genie_python.genie.cset") as cset, \
+            patch("genie_python.genie.check_alarms") as check_alarms, \
+            patch("genie_python.genie.waitfor_move") as waitfor_move:
+
+        def mock_cget(pv):
+            try:
+                return {"value": blocks[pv]}
+            except KeyError:
+                return None
+
+        def mock_cset(pv, value):
+            try:
+                blocks[pv] = value
+            except KeyError:
+                print("Block did not exist {}".format(pv))
+
+        def mock_check_alarms(*blocks_to_check):
+            blocks_to_check = list(blocks_to_check)
+            return [block for block in blocks_to_check if block in blocks_in_alarm]
+
+        def mock_waitfor_move(*args, **kwargs):
+            pass
+
+        cget.side_effect = mock_cget
+        cset.side_effect = mock_cset
+        check_alarms.side_effect = mock_check_alarms
+        waitfor_move.side_effect = mock_waitfor_move
+
+        for block, value in block_inits.items():
+            cset(block, value)
+
+        yield
+
+
+class ReflAutoHeightTest(unittest.TestCase):
+    """
+    Tests
+    """
+    laser_block = "laser"
+    height_block = "height"
+
+    @parameterized.expand([(1, 0, -1),
+                           (-1, 0, 1),
+                           (-1, -1, 0),
+                           (1, 1, 0),
+                           (2, 10, 8),
+                           (10, 2, -8)])
+    def test_GIVEN_laser_offset_WHEN_setting_auto_height_THEN_height_moves_by_difference(self, initial_laser_offset, initial_height, expected):
+        with genie_python_sim({self.laser_block: initial_laser_offset, self.height_block: initial_height}):
+
+            auto_height(self.laser_block, self.height_block)
+            actual = g.cget(self.height_block)["value"]
+
+            self.assertEqual(expected, actual)
+
+    @parameterized.expand([(0, 2, 2),
+                           (0, -2, -2),
+                           (1, 2, 1),
+                           (1, -2, -3),
+                           (-1, 2, 3),
+                           (-1, -2, -1)])
+    def test_GIVEN_laser_offset_and_non_default_target_WHEN_setting_auto_height_THEN_height_moves_by_difference_between_laser_and_target(self, initial_laser_offset, target, expected_height):
+        initial_height = 0
+        with genie_python_sim({self.laser_block: initial_laser_offset, self.height_block: initial_height}):
+
+            auto_height(self.laser_block, self.height_block, target=target)
+            actual_height = g.cget(self.height_block)["value"]
+
+            self.assertEqual(expected_height, actual_height)
+
+    def test_GIVEN_height_block_in_alarm_WHEN_setting_auto_height_THEN_alert_with_prompt(self):
+        with genie_python_sim({self.laser_block: 0, self.height_block: 0}, blocks_in_alarm=[self.height_block]), \
+             patch('general.utilities.io.alert_on_error') as alert_on_error:
+
+            auto_height(self.laser_block, self.height_block)
+
+            alert_on_error.assert_called_with(mock.ANY, True)
+
+    def test_GIVEN_laser_block_value_invalid_and_continue_is_false_WHEN_setting_auto_height_THEN_alert_with_prompt(self):
+        nonsense_val = "nonsense"
+        expected_prompt = True
+        with genie_python_sim({self.laser_block: nonsense_val, self.height_block: 0}), \
+             patch('general.utilities.io.alert_on_error') as alert_on_error:
+
+            auto_height(self.laser_block, self.height_block, continue_if_nan=False)
+
+            alert_on_error.assert_called_with(mock.ANY, expected_prompt)
+
+    def test_GIVEN_laser_block_value_invalid_and_continue_is_true_WHEN_setting_auto_height_THEN_alert_without_prompt(self):
+        nonsense_val = "nonsense"
+        expected_prompt = False
+        with genie_python_sim({self.laser_block: nonsense_val, self.height_block: 0}), \
+             patch('general.utilities.io.alert_on_error') as alert_on_error:
+
+            auto_height(self.laser_block, self.height_block, continue_if_nan=True)
+
+            alert_on_error.assert_called_with(mock.ANY, expected_prompt)
+
+    def test_GIVEN_blocks_not_in_alarm_and_no_nonsensical_values_WHEN_setting_auto_height_THEN_completed_without_alert(self):
+        with genie_python_sim({self.laser_block: 0, self.height_block: 0}), \
+             patch('general.utilities.io.alert_on_error') as alert_on_error:
+
+            auto_height(self.laser_block, self.height_block)
+
+            alert_on_error.assert_not_called()


### PR DESCRIPTION
### Instrument(s)

SURF, INTER

### Story/Acceptance criteria

SURF and INTER have a laser height gun installed above the sample point that provides a readout of the relative sample height. They would like to have an IBEX-equivalent to the OpenGENIE auto height function using this laser to automatically realign a sample. That function looks as follows:
```
PROCEDURE autoheight
 
LOCAL targetKeyence currentKeyence difference height targetHeight
 
targetKeyence = 0.0
currentKeyence = cshow(keyence)
currentKeyence = currentKeyence[1]
 
difference = currentKeyence-targetKeyence
 
height = cshow("fine_Z")
height = height[1]
 
IF (currentKeyence < 0)
      targetHeight = height + abs(difference)
ELSE
      targetHeight = height - abs(difference)
ENDIF
      
printn "target Height" + As_string(targetHeight)
      
cset fine_z = targetHeight
 
ENDPROCEDURE 
```

Notes (checked with INTER scientist): 
- Negative laser value means the axis has to move in a positive direction (and vice versa)
- Laser value is an offset from 0 where 0 typically means "centred on beam"
- Sometimes the laser gun reports NaN value (e.g. bad reflection). The scientists want to be able to choose whether these should block execution until the user intervenes, or whether the error should simply be ignored.
- The script should check whether the target value is within the operational range of the fine height axis (i.e. the coarse axis is in the right place). If not, this should always interrupt execution.

### Description of work

- Converted auto height to python function and added it to shared reflectometry scripts. 
- Added parameters for laser / sample fine height blocks as their names may differ between instruments. 
- Added an optional "target" parameter in case they want to align to a laser offset other than 0
- Added a check for alarms on the height block as this signifies a target outside of the operational range of the height axis (as per their request)
- Added an optional "continue_if_NaN" parameter which lets the scientists ignore invalid values from the laser height gun (as per their request)

### Issue/Ticket Reference

https://github.com/ISISComputingGroup/IBEX/issues/5930

### Tests

Tested manually with simulated motor and Keyence

### To test

1. Add blocks `height` on a simulated motor axis and `laser` on a simulated Keyence (but can be any block with a numerical value really)
2. Set `laser` to a non-zero value
3. Run `auto_height(b.height, b.laser)`. `height` should move by `laser` * (-1)
4. Run `auto_height(b.height, b.laser, target=x)`. `height` should move by x - `laser`
5. Run 'auto_height` as above but with a non numerical block for `b.laser`. This should interrupt the script with an appropriate error and prompt the user
6. Run 'auto_height` as above but with a non numerical block for `b.laser` and `continue_if_NaN`=True. This should throw an error but continue script execution
7. Run `auto_height` as above but with a `b.height` in alarm. This should interrupt the script with an appropriate error and prompt the user
---

#### Code Review

- [ ] Is the story/acceptance criteria fulfilled?
- [ ] Is the code of an acceptable quality?
- [ ] Are the tests sufficient?
- [ ] Do the changes function as described and is it robust?
- [ ] Are the changes able to work across all intended instruments?

### Final Steps
- [ ] Are there any changes to instrument configurations required?
- [ ] Are there any changes to instrument scripts required, e.g. change on script signature, default argument and have these been communicated?
- [ ] Does the script need to be deployed onto the instrument?
