### PR TITLE
Fix inter run angle script not setting any height

### DIFF
--- a/technique/reflectometry/base.py
+++ b/technique/reflectometry/base.py
@@ -422,7 +422,10 @@ class _Movement(object):
         """
         print("Sample: height offset from beam={}".format(height_offset))
         if not self.dry_run:
-            g.cset("SAMPLEOFFSET", height_offset)
+            if g._genie_api.get_instrument_full_name() == "NDXINTER":
+                g.cset("HEIGHT", height_offset)
+            else:
+                g.cset("SAMPLEOFFSET", height_offset)
 
     def set_height2_offset(self, height, constants):
         """
@@ -433,7 +436,10 @@ class _Movement(object):
         if constants.has_height2:
             print("Sample: height2 offset from beam={}".format(height))
             if not self.dry_run:
-                g.cset("HEIGHT2_OFFSET", height)
+                if g._genie_api.get_instrument_full_name() == "NDXINTER":
+                    g.cset("HEIGHT2", height)
+                else:
+                    g.cset("HEIGHT2_OFFSET", height)
         elif height != 0:
             print("ERROR: Height 2 off set is being ignored")
 


### PR DESCRIPTION
### Instrument(s)

INTER

### Story/Acceptance criteria

 run_angle script sets height correctly in INTER

### Description of work

Height blocks that run_angle was trying to write to were non-existent. Blocks were renamed to something that caters to INTER's naming scheme and is actually available.

### Issue/Ticket Reference

https://github.com/ISISComputingGroup/IBEX/issues/6499

### Tests

Describing the testing undertaken for this PR

### To test

Explain how the reviewer can test the changes made e.g. what state they need to be in do the tests

---

#### Code Review

- [ ] Is the story/acceptance criteria fulfilled?
- [ ] Is the code of an acceptable quality?
- [ ] Are the tests sufficient?
- [ ] Do the changes function as described and is it robust?
- [ ] Are the changes able to work across all intended instruments?

### Final Steps
- [ ] Are there any changes to instrument configurations required?
- [ ] Are there any changes to instrument scripts required, e.g. change on script signature, default argument and have these been communicated?
- [ ] Does the script need to be deployed onto the instrument?
