### PR TITLE
Scans: If folder doesn't exist create one or abort

### DIFF
--- a/general/scans/scans.py
+++ b/general/scans/scans.py
@@ -10,6 +10,7 @@ treated as private.
 """
 from __future__ import absolute_import, print_function
 
+import pdb
 from typing import TYPE_CHECKING
 
 from abc import ABCMeta, abstractmethod
@@ -29,6 +30,8 @@ if TYPE_CHECKING:
 from .monoid import ListOfMonoids, Monoid, Average, Exact
 from .detector import DetectorManager
 from .fit import Fit, ExactFit
+from pathlib import Path
+import os
 
 try:
     # pylint: disable=import-error
@@ -54,7 +57,7 @@ def _plot_range(array):
     if not (np.isfinite(low) and np.isfinite(high)):
         return (-1, 1)
     if not np.isfinite(low):
-        low = high-1
+        low = high - 1
     if not np.isfinite(high):
         high = low + 1
     diff = high - low
@@ -84,6 +87,10 @@ def estimate(seconds=None, minutes=None, hours=None,
         return 90 * uamps
 
     return 0
+
+def get_input(prompt: str):
+    return input(prompt)
+
 
 
 @add_metaclass(ABCMeta)
@@ -180,37 +187,52 @@ class Scan(object):
         acc = None
         action_remainder = None
         log_filename = self.defaults.log_file(self.log_file_info())
-        print("Writing data to: {}".format(log_filename))
-        with open(log_filename, "w") as logfile, \
-                detector(self, save=save, **kwargs) as detect:
-            for x in self:
-                # FIXME: Handle multidimensional plots
-                ((label, unit), position) = next(iter(x.items()))
 
-                # perform measurement
-                acc, value = detect(acc, **kwargs)
+        p = Path(log_filename)
+        log_path = p.parent
 
-                if isinstance(value, float):
-                    value = Average(value)
-                if not xs:
-                    logfile.write(
-                        "{} ({})\t{}\tUncertainty\n".format(
-                            label, unit, detector.unit))
-                if position in xs:
-                    ys[xs.index(position)] += value
-                else:
-                    xs.append(position)
-                    ys.append(value)
-                logfile.write("{}\t{}\t{}\n".format(xs[-1], str(ys[-1]),
-                                                    str(ys[-1].err())))
+        path_exists = os.path.isdir(log_path)
 
-                plot_functions.setup_plot(self.min(), self.max(), label, unit, y_unit=detector.unit)
-                plot_functions.plot_data_with_errors(xs, ys)
-                if action:
-                    action_remainder = action(xs, ys, plot_functions, action_remainder)
-                plot_functions.draw()
+        if path_exists:
+            print("Writing data to: {}".format(log_path))
+            with open(log_filename, "w") as logfile, \
+                    detector(self, save=save, **kwargs) as detect:
+                for x in self:
+                    # FIXME: Handle multidimensional plots
+                    ((label, unit), position) = next(iter(x.items()))
 
-        plot_functions.save(save)
+                    # perform measurement
+                    acc, value = detect(acc, **kwargs)
+
+                    if isinstance(value, float):
+                        value = Average(value)
+                    if not xs:
+                        logfile.write(
+                            "{} ({})\t{}\tUncertainty\n".format(
+                                label, unit, detector.unit))
+                    if position in xs:
+                        ys[xs.index(position)] += value
+                    else:
+                        xs.append(position)
+                        ys.append(value)
+                    logfile.write("{}\t{}\t{}\n".format(xs[-1], str(ys[-1]),
+                                                        str(ys[-1].err())))
+
+                    plot_functions.setup_plot(self.min(), self.max(), label, unit, y_unit=detector.unit)
+                    plot_functions.plot_data_with_errors(xs, ys)
+                    if action:
+                        action_remainder = action(xs, ys, plot_functions, action_remainder)
+                    plot_functions.draw()
+
+            plot_functions.save(save)
+
+        else:
+            print(f"Folder " + log_filename + " doesn't exist.")
+            user_input = get_input("Would you like this folder created (y) or the scan to be aborted (n)?")
+            if user_input == "y":
+                g.set_user_script_dir(log_path)
+            elif user_input == "n":
+                print("Abort")
 
         return action_remainder
 
@@ -247,8 +269,8 @@ class Scan(object):
             raise RuntimeError(
                 "Could not get result from plot. Perhaps the fit failed?")
         if isinstance(result[0], Iterable) and \
-           not isinstance(fit, ExactFit) and \
-           not isinstance(result, tuple):
+                not isinstance(fit, ExactFit) and \
+                not isinstance(result, tuple):
             result = np.array([x for x in result if x is not None])
             result = np.median(result, axis=0)
 


### PR DESCRIPTION

### Story/Acceptance criteria

- [ ] When folder doesn't exist ask if the user wants the script to create it (and either create it or abort the scan)
- [ ] If the folder can't be created inform the user with a warning
- [ ] When the folder does exist the user should not be prompted
- [ ] Add a test for this specific function

### Description of work
With this new functionality; if the user wishes to execute a scan and write it to a folder that has not been created, they can either create the folder or abort the scan.

### Issue/Ticket Reference

https://github.com/ISISComputingGroup/IBEX/issues/5867

### Tests

`test_GIVEN_scan_writes_non_existing_folder_WHEN_change_log_file_THEN_create_new_folder `is created in `test_scans.py` to test this functionality

### To test

1. cd to _Instrument/scripts_
2. Run `%PYTHON3% -m unittest general.scans.test.test_scans.TestScans.test_GIVEN_scan_writes_non_existing_folder_WHEN_change_log_file_THEN_create_new_folder`



---

#### Code Review

- [ ] Is the story/acceptance criteria fulfilled?
- [ ] Is the code of an acceptable quality?
- [ ] Are the tests sufficient?
- [ ] Do the changes function as described and is it robust?
- [ ] Are the changes able to work across all intended instruments?

### Final Steps
- [ ] Are there any changes to instrument configurations required?
- [ ] Are there any changes to instrument scripts required, e.g. change on script signature, default argument and have these been communicated?
- [ ] Does the script need to be deployed onto the instrument?
