### PR TITLE
Create Background Script for Tektronix Oscilloscope Screenshots

### DIFF
--- a/technique/muon/tektronix_osc_screenshots.py
+++ b/technique/muon/tektronix_osc_screenshots.py
@@ -13,7 +13,6 @@ sys.path.insert(0, os.path.abspath(os.path.join(r"C:\\", "Instrument", "scripts"
 sys.path.insert(0, os.path.abspath(os.path.join(os.environ["EPICS_KIT_ROOT"], "ISIS", "inst_servers", "master")))
 
 from genie_python import genie as g
-from genie_python.channel_access_exceptions import UnableToConnectToPVException
 from server_common.helpers import register_ioc_start
 
 register_ioc_start("BGRSCRPT_03")

--- a/technique/muon/tektronix_osc_screenshots.py
+++ b/technique/muon/tektronix_osc_screenshots.py
@@ -36,6 +36,7 @@ def get_image() -> Image:
 
 while not TESTING:
     try:
+        print("Creating filenames...")
         run_number = g.get_runnumber()
         rb_number = g.get_rb()
         base_dir = "C:\\data\\"
@@ -43,35 +44,35 @@ while not TESTING:
         zip_archive_file_path = zip_base_file_path + "_scope_screens.zip"
         zip_temp_file_path = zip_base_file_path + "_scope_screens_temp.zip"
 
-        # Poll the device's web server for the image
+        print("Polling device for image...")
         img = get_image()
 
-        # Save the image in the form <RUN #>_<DATETIME STAMP>.png
+        print("Saving image to file system...")
         image_file_name = get_filename(rb_number)
         img.save(base_dir + image_file_name)
 
-        # If it exists, make a copy of the existing zip file
+        print("Making a temporary copy of the archive zip file...")
         try:
             shutil.copy2(zip_archive_file_path, zip_temp_file_path) #  copy2 preserves metadata
         except IOError as ioe:
-            print("Failed to make a copy of the zip archive. Making a new one.\n")
+            print("Failed to make a copy of the zip archive. Making a new one.")
 
-        # Write the new image into the zip file.
+        print("Writing the new image to the temp zip archive...")
         with ZipFile(zip_temp_file_path, "a") as zip:
             zip.write(base_dir + image_file_name, "oscilloscope_screenshots\\" + image_file_name)
 
-        # Overwrite the original file with the new one
+        print("Replacing the original zip file with the temp one...")
         shutil.copy2(zip_temp_file_path, zip_archive_file_path)
 
-        # Delete the temp file & image file
+        print("Removing temporary files...")
         os.remove(zip_temp_file_path)
         os.remove(base_dir + image_file_name)
     except TypeError as te:
         if str(te) == 'can only concatenate str (not "NoneType") to str':
-            print("ERROR: Could not determine run/rb number. Check DAE connection.\n")
+            print("ERROR: Could not determine run/rb number. Check DAE connection.")
     except AttributeError as ae:
         if str(ae) == "'NoneType' object has no attribute 'get_run_number'":
-            print("ERROR: Could not determine run number. Check DAE connection.\n")
+            print("ERROR: Could not determine run number. Check DAE connection.")
         else:
             print(ae)
     except requests.Timeout as to:
@@ -79,12 +80,12 @@ while not TESTING:
             "ERROR: Image collection from oscilloscope timed out.\n"
             f"Check that the web server on the device is working by typing {DEVICE_IP} into a browser's address bar. "
             "If the image from the oscillocope's screen is not showing or the page does not load, "
-            "the device may need to be rebooted.\n"
+            "the device may need to be rebooted."
             )
     except IOError as ioe:
         print(f"ERROR: Unable to replace {zip_archive_file_path}. It may have been set to read-only by the archive script.\n"
         + str(ioe))
 
     finally:
-        # Wait 10 minutes and start again
+        print(f"Waiting for {MINS_BETWEEN_SCREENSHOTS} minutes...")
         sleep(MINS_BETWEEN_SCREENSHOTS * 60)  # Only pull an image after a user defined number of minutes

--- a/technique/muon/tektronix_osc_screenshots.py
+++ b/technique/muon/tektronix_osc_screenshots.py
@@ -10,7 +10,7 @@ from time import sleep
 from zipfile import ZipFile
 
 sys.path.insert(0, os.path.abspath(os.path.join(r"C:\\", "Instrument", "scripts")))
-sys.path.insert(0, os.path.abspath(os.path.join(os.environ["KIT_ROOT"], "ISIS", "inst_servers", "master")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.environ["EPICS_KIT_ROOT"], "ISIS", "inst_servers", "master")))
 
 from genie_python import genie as g
 from genie_python.channel_access_exceptions import UnableToConnectToPVException

--- a/technique/muon/tektronix_osc_screenshots.py
+++ b/technique/muon/tektronix_osc_screenshots.py
@@ -28,7 +28,7 @@ MINS_BETWEEN_SCREENSHOTS = 10
 TESTING = False  # Stops the permanent while loop running for testing the functions. 
 
 def get_filename(rb_number: str) -> str:
-    return rb_number + "_" + datetime.now().replace(microsecond=0).isoformat().replace(":", "-") + ".png"
+    return f'{rb_number}_{datetime.now().replace(microsecond=0).isoformat().replace(":", "-")}.png'
 
 def get_image() -> Image:
     response = requests.get(f"http://{DEVICE_IP}/image.png", timeout=10)
@@ -59,7 +59,7 @@ while not TESTING:
 
         print("Writing the new image to the temp zip archive...")
         with ZipFile(zip_temp_file_path, "a") as zip:
-            zip.write(base_dir + image_file_name, "oscilloscope_screenshots\\" + image_file_name)
+            zip.write(base_dir + image_file_name, f"oscilloscope_screenshots\\{image_file_name}")
 
         print("Replacing the original zip file with the temp one...")
         shutil.copy2(zip_temp_file_path, zip_archive_file_path)

--- a/technique/muon/tektronix_osc_screenshots.py
+++ b/technique/muon/tektronix_osc_screenshots.py
@@ -25,7 +25,16 @@ DEVICE_IP = "130.246.50.7"
 INSTRUMENT = "EXAMPLE_INST"
 MINS_BETWEEN_SCREENSHOTS = 10
 
-while True:
+TESTING = False  # Stops the permanent while loop running for testing the functions. 
+
+def get_filename(rb_number: str) -> str:
+    return rb_number + "_" + datetime.now().replace(microsecond=0).isoformat().replace(":", "-") + ".png"
+
+def get_image() -> Image:
+    response = requests.get(f"http://{DEVICE_IP}/image.png", timeout=10)
+    return Image.open(BytesIO(response.content))
+
+while not TESTING:
     try:
         run_number = g.get_runnumber()
         rb_number = g.get_rb()
@@ -35,11 +44,10 @@ while True:
         zip_temp_file_path = zip_base_file_path + "_scope_screens_temp.zip"
 
         # Poll the device's web server for the image
-        response = requests.get(f"http://{DEVICE_IP}/image.png", timeout=10)
-        img = Image.open(BytesIO(response.content))
+        img = get_image()
 
         # Save the image in the form <RUN #>_<DATETIME STAMP>.png
-        image_file_name = rb_number + "_" + datetime.now().replace(microsecond=0).isoformat().replace(":", "-") + ".png"
+        image_file_name = get_filename(rb_number)
         img.save(base_dir + image_file_name)
 
         # If it exists, make a copy of the existing zip file
@@ -79,4 +87,4 @@ while True:
 
     finally:
         # Wait 10 minutes and start again
-        sleep(MINS_BETWEEN_SCREENSHOTS * 60)  # Only pull an image every 10 minutes
+        sleep(MINS_BETWEEN_SCREENSHOTS * 60)  # Only pull an image after a user defined number of minutes

--- a/technique/muon/tektronix_osc_screenshots.py
+++ b/technique/muon/tektronix_osc_screenshots.py
@@ -39,17 +39,18 @@ while not TESTING:
         print("Creating filenames...")
         run_number = g.get_runnumber()
         rb_number = g.get_rb()
-        base_dir = "C:\\data\\"
-        zip_base_file_path = base_dir + "NDX" + INSTRUMENT + run_number
-        zip_archive_file_path = zip_base_file_path + "_scope_screens.zip"
-        zip_temp_file_path = zip_base_file_path + "_scope_screens_temp.zip"
+        base_dir = os.path.join(f"C:{os.sep}", "data")
+        zip_filename = f"NDX{INSTRUMENT}{run_number}"
+        zip_archive_file_path = os.path.join(base_dir, f"{zip_filename}_scope_screens.zip")
+        zip_temp_file_path = os.path.join(base_dir, f"{zip_filename}_scope_screens_temp.zip")
 
         print("Polling device for image...")
         img = get_image()
 
         print("Saving image to file system...")
         image_file_name = get_filename(rb_number)
-        img.save(base_dir + image_file_name)
+        image_file_path = os.path.join(base_dir, image_file_name)
+        img.save(image_file_path)
 
         print("Making a temporary copy of the archive zip file...")
         try:
@@ -59,14 +60,14 @@ while not TESTING:
 
         print("Writing the new image to the temp zip archive...")
         with ZipFile(zip_temp_file_path, "a") as zip:
-            zip.write(base_dir + image_file_name, f"oscilloscope_screenshots\\{image_file_name}")
+            zip.write(image_file_path, os.path.join("oscilloscope_screenshots", image_file_name))
 
         print("Replacing the original zip file with the temp one...")
         shutil.copy2(zip_temp_file_path, zip_archive_file_path)
 
         print("Removing temporary files...")
         os.remove(zip_temp_file_path)
-        os.remove(base_dir + image_file_name)
+        os.remove(image_file_path)
     except TypeError as te:
         if str(te) == 'can only concatenate str (not "NoneType") to str':
             print("ERROR: Could not determine run/rb number. Check DAE connection.")

--- a/technique/muon/tektronix_osc_screenshots.py
+++ b/technique/muon/tektronix_osc_screenshots.py
@@ -21,7 +21,7 @@ register_ioc_start("BGRSCRPT_03")
 g.set_instrument(None)
 
 # User editable constants
-DEVICE_IP = "130.246.50.7"
+DEVICE_IP = ""
 INSTRUMENT = "EXAMPLE_INST"
 MINS_BETWEEN_SCREENSHOTS = 10
 

--- a/technique/muon/tektronix_osc_screenshots.py
+++ b/technique/muon/tektronix_osc_screenshots.py
@@ -71,6 +71,8 @@ while not TESTING:
     except TypeError as te:
         if str(te) == 'can only concatenate str (not "NoneType") to str':
             print("ERROR: Could not determine run/rb number. Check DAE connection.")
+        else:
+            print(te)
     except AttributeError as ae:
         if str(ae) == "'NoneType' object has no attribute 'get_run_number'":
             print("ERROR: Could not determine run number. Check DAE connection.")
@@ -84,8 +86,7 @@ while not TESTING:
             "the device may need to be rebooted."
             )
     except IOError as ioe:
-        print(f"ERROR: Unable to replace {zip_archive_file_path}. It may have been set to read-only by the archive script.\n"
-        + str(ioe))
+        print(str(ioe))
 
     finally:
         print(f"Waiting for {MINS_BETWEEN_SCREENSHOTS} minutes...")

--- a/technique/muon/tests/test_tektronix_osc_screenshots.py
+++ b/technique/muon/tests/test_tektronix_osc_screenshots.py
@@ -1,0 +1,24 @@
+# Set genie python to simulate
+import os
+os.environ["GENIE_SIMULATE"] = "1"
+
+# Imports come after to prevent import of genie python not in simulation
+import unittest
+from technique.muon import tektronix_osc_screenshots
+from genie_python import genie as g
+from unittest.mock import patch, MagicMock
+
+from datetime import datetime
+
+class TestOscScreenshots(unittest.TestCase):
+    
+    def setUp(self) -> None:
+        pass
+
+    @patch("technique.muon.tektronix_osc_screenshots.datetime")
+    def test_GIVEN_known_RB_and_time_WHEN_get_filename_called_THEN_correct_format_returned(self, dt):
+        rb = "RB101"
+        timestamp = datetime(2022, 10, 14, 9, 36, 24, 1204)
+        dt.now.return_value = timestamp
+
+        self.assertEqual("RB101_2022-10-14T09-36-24.png", tektronix_osc_screenshots.get_filename(rb))


### PR DESCRIPTION
### Instrument(s)

Muons, Osc was taken from EMU but I'm fairly sure other instruments want similar functionality. 

### Story/Acceptance criteria

As a user, I want to be able to run a script background script that takes an image from the oscilloscope every 10 minutes and saves it into the archive as a `.png`. 

### Description of work

Adds the described script, allowing

### Issue/Ticket Reference

ISISComputingGroup/IBEX#7318


### To test
1. Boot up the IBEX server
2. Run the script with the oscilloscope off
3. Check that the appropriate error message is shown when it can't connect
4. Boot the oscilloscope
5. Put the IP address into the script constants and drop the time bettween screenshots to a few seconds
6. Run the script again, this time checking that a zip file is created with a dir inside that contains the oscilloscope images. They should be marked with the rb number and a timestamp. 

Partially Resolves ISISComputingGroup/IBEX#7318

---

#### Code Review

- [ ] Is the story/acceptance criteria fulfilled?
- [ ] Is the code of an acceptable quality?
- [ ] Are the tests sufficient?
- [ ] Do the changes function as described and is it robust?
- [ ] Are the changes able to work across all intended instruments?

### Final Steps
- [ ] Are there any changes to instrument configurations required?
- [ ] Are there any changes to instrument scripts required, e.g. change on script signature, default argument and have these been communicated?
- [ ] Does the script need to be deployed onto the instrument?
