### PR TITLE
Do_sans/trans Fixes for ZOOM

### DIFF
--- a/instrument/loq/sans.py
+++ b/instrument/loq/sans.py
@@ -13,12 +13,7 @@ class LOQ(ScanningInstrument):
 
     def __init__(self):
         super().__init__()
-        self.setup_sans = self.setup_dae_histogram
-        try:
-            self._poslist_dls = self.get_pv("LKUP:DLS:POSITIONS").split()
-        except AttributeError:
-            warning("No positions found for DLS Sample Changer!")
-            self._poslist_dls = []
+        self._set_poslist_dls()
 
     def do_sans_large(self, title=None, pos=None, thickness=1.0,
                       dae=None, uamps=None, time=None, **kwargs):
@@ -200,20 +195,6 @@ class LOQ(ScanningInstrument):
         sleep(1)
         gen.cset(Julabo_2_Circulator="ON")
         gen.waitfor_move()
-
-    def check_move_pos_dls(self, pos):
-        """Check whether the position is valid for the DLS sample changer and return True or False
-
-        Parameters
-        ----------
-        pos : str
-          The sample changer position
-
-        """
-        if pos not in self._poslist_dls:
-            warning(f"Error in script, position {pos} does not exist")
-            return False
-        return True
 
 
 obj = LOQ()

--- a/instrument/loq/sans.py
+++ b/instrument/loq/sans.py
@@ -14,7 +14,11 @@ class LOQ(ScanningInstrument):
     def __init__(self):
         super().__init__()
         self.setup_sans = self.setup_dae_histogram
-        self._poslist_dls = self.get_pv("LKUP:DLS:POSITIONS").split()
+        try:
+            self._poslist_dls = self.get_pv("LKUP:DLS:POSITIONS").split()
+        except AttributeError:
+            warning("No positions found for DLS Sample Changer!")
+            self._poslist_dls = []
 
     def do_sans_large(self, title=None, pos=None, thickness=1.0,
                       dae=None, uamps=None, time=None, **kwargs):

--- a/instrument/sans2d/sans.py
+++ b/instrument/sans2d/sans.py
@@ -12,11 +12,8 @@ class Sans2d(ScanningInstrument):
 
     def __init__(self):
         super().__init__()
-        try:
-            self._poslist_dls = self.get_pv("LKUP:DLS:POSITIONS").split()
-        except AttributeError:
-            warning("No positions found for DLS Sample Changer!")
-            self._poslist_dls = []
+        self._set_poslist_dls()
+
     def check_move_pos(self, pos):
         """Check whether the position is valid for the normal
         sample changer and return True or False
@@ -28,21 +25,6 @@ class Sans2d(ScanningInstrument):
 
         """
         if pos not in self._poslist:
-            warning(f"Error in script, position {pos} does not exist")
-            return False
-        return True
-
-    def check_move_pos_dls(self, pos):
-        """Check whether the position is valid for the DSL sample
-         changer and return True or False
-
-        Parameters
-        ----------
-        pos : str
-          The sample changer position
-
-        """
-        if pos not in self._poslist_dls:
             warning(f"Error in script, position {pos} does not exist")
             return False
         return True

--- a/instrument/sans2d/sans.py
+++ b/instrument/sans2d/sans.py
@@ -12,8 +12,11 @@ class Sans2d(ScanningInstrument):
 
     def __init__(self):
         super().__init__()
-        self._poslist_dls = self.get_pv("LKUP:DLS:POSITIONS").split()
-
+        try:
+            self._poslist_dls = self.get_pv("LKUP:DLS:POSITIONS").split()
+        except AttributeError:
+            warning("No positions found for DLS Sample Changer!")
+            self._poslist_dls = []
     def check_move_pos(self, pos):
         """Check whether the position is valid for the normal
         sample changer and return True or False
@@ -44,14 +47,14 @@ class Sans2d(ScanningInstrument):
             return False
         return True
 
-    def do_sans_large(self, title="", position=None, thickness=1.0, dae=None,
-                    period=None, time=None, dls_sample_changer=False, **kwargs):
+    def do_sans_large(self, title="", pos=None, thickness=1.0, dae=None,
+                      period=None, time=None, dls_sample_changer=False, **kwargs):
         """
         A wrapper around do_sans with aperture set to large
         Please see measure for full documentation of parameters
         """
-        self.do_sans(title=title, position=position, thickness=thickness, dae=dae,
-                period=period, aperture="LARGE", time=time, dls_sample_changer=dls_sample_changer, **kwargs)
+        self.do_sans(title=title, pos=pos, thickness=thickness, dae=dae,
+                     period=period, aperture="LARGE", time=time, dls_sample_changer=dls_sample_changer, **kwargs)
 
     def _generic_scan(self, detector, spectra, wiring, tcbs=None):
         if tcbs is None:

--- a/instrument/zoom/sans.py
+++ b/instrument/zoom/sans.py
@@ -11,8 +11,11 @@ class Zoom(ScanningInstrument):
     of the Scanning instrument class."""
     def __init__(self):
         super().__init__()
-        # TODO fix DLS motionsetpoints lookup
-#        _poslist_dls = self.get_pv("LKUP:DLS:POSITIONS").split()
+        try:
+            self._poslist_dls = self.get_pv("LKUP:DLS:POSITIONS").split()
+        except AttributeError:
+            warning("No positions found for DLS Sample Changer!")
+            self._poslist_dls = []
 
     def _generic_scan(self, detector, spectra, wiring="detector_1det_1dae3card.dat", tcbs=None):
         # Explicitly check and then set to default value to avoid UB.
@@ -74,10 +77,9 @@ class Zoom(ScanningInstrument):
           The sample changer position
 
         """
-        # TODO fix DLS motionsetpoints lookup
-#        if pos not in self._poslist_dls:
-#            warning(f"Error in script, position {pos} does not exist")
-#            return False
+        if pos not in self._poslist_dls:
+            warning(f"Error in script, position {pos} does not exist")
+            return False
         return True
 
 

--- a/instrument/zoom/sans.py
+++ b/instrument/zoom/sans.py
@@ -11,7 +11,8 @@ class Zoom(ScanningInstrument):
     of the Scanning instrument class."""
     def __init__(self):
         super().__init__()
-        _poslist_dls = self.get_pv("LKUP:DLS:POSITIONS").split()
+        # TODO fix DLS motionsetpoints lookup
+#        _poslist_dls = self.get_pv("LKUP:DLS:POSITIONS").split()
 
     def _generic_scan(self, detector, spectra, wiring="detector_1det_1dae3card.dat", tcbs=None):
         # Explicitly check and then set to default value to avoid UB.
@@ -57,11 +58,11 @@ class Zoom(ScanningInstrument):
 
     def _configure_sans_custom(self):
         # move the transmission monitor out
-        self.send_pv("VACUUM:MONITOR:4:SP", "EXTRACTED")
+        self.send_pv("VACUUM:MONITOR:4:EXTRACT", "EXTRACT")
 
     def _configure_trans_custom(self):
         # move the transmission monitor in
-        self.send_pv("VACUUM:MONITOR:4:SP", "INSERTED")
+        self.send_pv("VACUUM:MONITOR:4:INSERT", "INSERT")
 
     def check_move_pos_dls(self, pos):
         """Check whether the position is valid for the DSL sample
@@ -73,9 +74,10 @@ class Zoom(ScanningInstrument):
           The sample changer position
 
         """
-        if pos not in self._poslist_dls:
-            warning(f"Error in script, position {pos} does not exist")
-            return False
+        # TODO fix DLS motionsetpoints lookup
+#        if pos not in self._poslist_dls:
+#            warning(f"Error in script, position {pos} does not exist")
+#            return False
         return True
 
 

--- a/instrument/zoom/sans.py
+++ b/instrument/zoom/sans.py
@@ -11,11 +11,7 @@ class Zoom(ScanningInstrument):
     of the Scanning instrument class."""
     def __init__(self):
         super().__init__()
-        try:
-            self._poslist_dls = self.get_pv("LKUP:DLS:POSITIONS").split()
-        except AttributeError:
-            warning("No positions found for DLS Sample Changer!")
-            self._poslist_dls = []
+        self._set_poslist_dls()
 
     def _generic_scan(self, detector, spectra, wiring="detector_1det_1dae3card.dat", tcbs=None):
         # Explicitly check and then set to default value to avoid UB.
@@ -66,21 +62,6 @@ class Zoom(ScanningInstrument):
     def _configure_trans_custom(self):
         # move the transmission monitor in
         self.send_pv("VACUUM:MONITOR:4:INSERT", "INSERT")
-
-    def check_move_pos_dls(self, pos):
-        """Check whether the position is valid for the DSL sample
-         changer and return True or False
-
-        Parameters
-        ----------
-        pos : str
-          The sample changer position
-
-        """
-        if pos not in self._poslist_dls:
-            warning(f"Error in script, position {pos} does not exist")
-            return False
-        return True
 
 
 obj = Zoom()

--- a/technique/sans/instrument.py
+++ b/technique/sans/instrument.py
@@ -445,8 +445,7 @@ class ScanningInstrument(object):
         return True
 
     def check_move_pos_dls(self, pos):
-        """Check whether the position is valid for the DSL sample
-         changer and return True or False
+        """Check whether the position is valid for the DLS sample changer and return True or False
 
         Parameters
         ----------
@@ -454,7 +453,16 @@ class ScanningInstrument(object):
           The sample changer position
 
         """
-        NotImplementedError("DSL sample change is unsupported on this instrument")
+        if self._poslist_dls is None:
+            NotImplementedError("DLS sample changer is unsupported on this instrument")
+
+        elif self._poslist_dls is []:
+            self._set_poslist_dls()
+
+        if pos not in self._poslist_dls:
+            warning(f"Error in script, position {pos} does not exist")
+            return False
+        return True
 
     @property
     def changer_pos(self):
@@ -949,3 +957,10 @@ class ScanningInstrument(object):
           The aperture size. e.g. "Small" or "Medium"
           A blank string (the default value) results in
           the aperture not being changed."""
+
+    def _set_poslist_dls(self):
+        try:
+            self._poslist_dls = self.get_pv("LKUP:DLS:POSITIONS").split()
+        except AttributeError:
+            warning("No positions found for DLS Sample Changer!")
+            self._poslist_dls = []

--- a/technique/sans/instrument.py
+++ b/technique/sans/instrument.py
@@ -63,8 +63,6 @@ class ScanningInstrument(object):
     _detector_lock = False
     title_footer = ""
     _TIMINGS = ["uamps", "frames", "seconds", "minutes", "hours"]
-    # Gets the instruments prefix to be used with all pv commands
-    _PV_BASE = gen.my_pv_prefix
     # Methods to ignore in method_iterator
     _block_accessors = ["changer_pos_dls", "changer_pos", "method_iterator"]
 
@@ -870,7 +868,7 @@ class ScanningInstrument(object):
         change the value of the PV for "IN:LARMOR:DAE:WIRING_FILE" to
         the value in f.
         """
-        return gen.set_pv(self._PV_BASE + name, value)
+        return gen.set_pv(name, value, is_local=True)
 
     @property
     def tables_path(self):

--- a/technique/sans/instrument.py
+++ b/technique/sans/instrument.py
@@ -455,6 +455,7 @@ class ScanningInstrument(object):
         """
         if self._poslist_dls is None:
             NotImplementedError("DLS sample changer is unsupported on this instrument")
+            return False
 
         elif self._poslist_dls is []:
             self._set_poslist_dls()

--- a/technique/sans/instrument.py
+++ b/technique/sans/instrument.py
@@ -861,7 +861,7 @@ class ScanningInstrument(object):
         the value of the PV for "IN:LARMOR:DAE:WIRING_FILE"
 
         """
-        return gen.get_pv(self._PV_BASE + name)
+        return gen.get_pv(name, is_local=True)
 
     def send_pv(self, name, value):
         """Set the given PV within the sub hierarchy of the instrument.

--- a/technique/sans/instrument.py
+++ b/technique/sans/instrument.py
@@ -669,7 +669,7 @@ class ScanningInstrument(object):
         if time or self.sanitised_timings(kwargs):
             self._do_measure(title=title, time=time, **kwargs)
 
-    def do_sans(self, title="", position=None, thickness=1.0, dae=None,
+    def do_sans(self, title="", pos=None, thickness=1.0, dae=None,
                 aperture="", period=None, time=None, dls_sample_changer=False, **kwargs):
         """A wrapper around ``measure`` which ensures that the instrument is
         in sans mode before running the measurement if a title is given.
@@ -685,7 +685,7 @@ class ScanningInstrument(object):
         of parameters accepted. """
 
         if gen.get_runstate() != "SETUP":  # pragma: no cover
-            self._attempt_resume(title, position, thickness, dae, **kwargs)
+            self._attempt_resume(title, pos, thickness, dae, **kwargs)
             return
 
         info("Set up instrument for sans measurement")
@@ -696,7 +696,7 @@ class ScanningInstrument(object):
 
         if "trans" in kwargs:
             del kwargs["trans"]
-        self._measure(title=title, trans=False, position=position, thickness=thickness,
+        self._measure(title=title, trans=False, position=pos, thickness=thickness,
                       dae=dae, aperture=aperture, period=period,
                       time=time, _custom=False, dls_sample_changer=dls_sample_changer, **kwargs)
 


### PR DESCRIPTION
Fixes to refactored do_sans/trans routines that we made to make it work while commissioning on ZOOM

- Added checks to protect against scripts falling over if DLS motion setpoints are not set up (can be removed once this is done for LOQ, SANS2D, ZOOM)
- renamed `position` argument to `pos`, requested by ZOOM scientists to keep with their naming convention throughout existing scripts. This was a new addition in https://github.com/ISISComputingGroup/IBEX/issues/7132 so should not break anything
- fixed Monitor 4 PV writes
- fixed get_pv/send_pv (it failed previously when appending the prefix, not sure why, this seems a bit neater either way)