### PR TITLE
Ticket7908 correct default behaviour

### DIFF
--- a/instrument/loq/sans.py
+++ b/instrument/loq/sans.py
@@ -15,7 +15,7 @@ class LOQ(ScanningInstrument):
         super().__init__()
         self._set_poslist_dls()
 
-    def do_sans_large(self, title=None, pos=None, thickness=1.0,
+    def do_sans_large(self, title=None, pos=None, thickness=None,
                       dae=None, uamps=None, time=None, **kwargs):
         """
         A wrapper around do_sans with aperture set to large

--- a/instrument/sans2d/sans.py
+++ b/instrument/sans2d/sans.py
@@ -14,7 +14,7 @@ class Sans2d(ScanningInstrument):
         super().__init__()
         self._set_poslist_dls()
 
-    def do_sans_large(self, title="", pos=None, thickness=1.0, dae=None,
+    def do_sans_large(self, title=None, pos=None, thickness=None, dae=None,
                       period=None, time=None, dls_sample_changer=False, **kwargs):
         """
         A wrapper around do_sans with aperture set to large

--- a/technique/sans/instrument.py
+++ b/technique/sans/instrument.py
@@ -629,7 +629,7 @@ class ScanningInstrument(object):
                       dae=dae, aperture=aperture, time=time,
                       period=period, _custom=True, dls_sample_changer=dls_sample_changer, **kwargs)
 
-    def _setup(self, title="", position=None, thickness=1.0, trans=False,
+    def _setup(self, title="", position=None, thickness=None, trans=False,
                dae=None, aperture="", period=None,
                _custom=True, dls_sample_changer=False, **kwargs):
         # Check detector for sans
@@ -658,7 +658,8 @@ class ScanningInstrument(object):
             info(f"Moving {arg} to {val}")
             gen.cset(arg, val)
         gen.waitfor_move()
-        gen.change_sample_par("Thick", thickness)
+        if thickness:
+            gen.change_sample_par("Thick", thickness)
         info("Using the following Sample Parameters")
         self.print_sample_pars()
         if period:
@@ -694,7 +695,7 @@ class ScanningInstrument(object):
         self._waitfor(**times)
         self._end()
 
-    def _measure(self, title="", position=None, thickness=1.0, trans=False,
+    def _measure(self, title="", position=None, thickness=None, trans=False,
                  dae=None, aperture="", period=None,
                  time=None, _custom=True, **kwargs):
 
@@ -706,7 +707,7 @@ class ScanningInstrument(object):
         if time or self.sanitised_timings(kwargs):
             self._do_measure(title=title, time=time, **kwargs)
 
-    def do_sans(self, title="", pos=None, thickness=1.0, dae=None,
+    def do_sans(self, title="", pos=None, thickness=None, dae=None,
                 aperture="", period=None, time=None, dls_sample_changer=False, **kwargs):
         """A wrapper around ``measure`` which ensures that the instrument is
         in sans mode before running the measurement if a title is given.

--- a/technique/sans/instrument.py
+++ b/technique/sans/instrument.py
@@ -738,7 +738,7 @@ class ScanningInstrument(object):
                       dae=dae, aperture=aperture, period=period,
                       time=time, _custom=False, dls_sample_changer=dls_sample_changer, **kwargs)
 
-    def do_trans(self, title="", pos=None, thickness=1.0, dae=None,
+    def do_trans(self, title="", pos=None, thickness=None, dae=None,
                  aperture="", period=None, time=None, dls_sample_changer=False, **kwargs):
         """A wrapper around ``measure`` which ensures that the instrument is
          in transition mode before running the measurement if a title is given. It ensures that the

--- a/technique/sans/instrument.py
+++ b/technique/sans/instrument.py
@@ -645,9 +645,10 @@ class ScanningInstrument(object):
 
         if title is None:
             full_title = gen.get_title()
+            part_title = title
             if full_title.endswith(self.title_footer):
-                title = full_title[:-len(self.title_footer)]
-            self.measurement_label = title
+                part_title = full_title[:-len(self.title_footer)]
+            self.measurement_label = part_title
             gen.change(title=full_title)
         else:
             self.measurement_label = title


### PR DESCRIPTION
### Instrument(s)

SANS instruments

### Story/Acceptance criteria

Remove default values from certain methods, which overwrote thickness and title if not specified

### Issue/Ticket Reference

[Ticket7908](https://github.com/ISISComputingGroup/IBEX/issues/7908)

### To test
Be confident that when do_sans/do_trans/measure functions called, title and thickness are not overwritten unless set to.

---

#### Code Review

- [ ] Is the story/acceptance criteria fulfilled?
- [ ] Is the code of an acceptable quality?
- [ ] Are the tests sufficient?
- [ ] Do the changes function as described and is it robust?
- [ ] Are the changes able to work across all intended instruments?

### Final Steps
- [ ] Are there any changes to instrument configurations required?
- [ ] Are there any changes to instrument scripts required, e.g. change on script signature, default argument and have these been communicated?
- [ ] Does the script need to be deployed onto the instrument?
